### PR TITLE
feat: add probing CLI mode detection and initialization skip

### DIFF
--- a/python/probing/cli/__main__.py
+++ b/python/probing/cli/__main__.py
@@ -1,18 +1,13 @@
+import os
 import sys
+
+# Set CLI mode before any probing imports to skip probe initialization
+os.environ["PROBING_CLI_MODE"] = "1"
 
 
 def main():
     """Entry point for the probing CLI command."""
-    # Import probing module - this will load _core via maturin
-    # cli_main is exported from probing.__init__.py which imports it from _core
     import probing
-
-    # cli_main is available from probing module (exported from __init__.py)
-    if not hasattr(probing, "cli_main"):
-        raise ImportError(
-            "cli_main is not available in probing module. "
-            "Please ensure the probing package is properly installed."
-        )
 
     probing.cli_main(["probing"] + sys.argv[1:])
 


### PR DESCRIPTION
- Introduced `is_probing_cli` function to check if the current process is the probing CLI, preventing probe injection into itself.
- Updated probing initialization logic to skip when running in CLI mode.
- Set `PROBING_CLI_MODE` environment variable in the CLI entry point to control probing behavior.
- Enhanced Rust setup to avoid initialization and cleanup when in CLI mode.