### PR TITLE
Add accelerator timing module with unit and GPU tests

### DIFF
--- a/python/probing/timing/__init__.py
+++ b/python/probing/timing/__init__.py
@@ -1,0 +1,109 @@
+"""
+Accelerator Timing
+
+Spec
+----
+This package measures how long CUDA workloads take using stream-value-gated
+CUDA events (the ``cuda_event_wait_value32_ffi`` method), which exclude host
+enqueue latency from the measurement.
+
+Usage:
+    from probing.timing import timing, timing_context
+
+    @timing
+    def gemm():
+        return a @ b
+
+    with timing_context(device=0) as ctx:
+        gemm()
+    elapsed_ms = ctx["gemm"]
+    method = ctx.methods["gemm"]
+
+A ``@timing`` workload is timed only while a ``timing_context`` is active on the
+current thread; outside a context it runs untouched. Timing requires a CUDA
+device that supports driver stream memory operations; there is no fallback
+timer.
+
+Public Interfaces:
+- `timing`: decorate a workload so the active context records its elapsed time.
+- `timing_context`: open a context that collects ``@timing`` measurements.
+- `TimingContext`: the context object (records / values / methods).
+- `TimingRecord`: a single measurement (elapsed_ms / method / value).
+- `AcceleratorTimer`: the underlying timer for standalone use.
+"""
+from __future__ import annotations
+
+import contextvars
+import functools
+
+from probing.timing.backend import _torch
+from probing.timing.timer import AcceleratorTimer, TimingRecord
+
+_CURRENT_CONTEXT = contextvars.ContextVar("probing_timing_context", default=None)
+
+
+class TimingContext:
+    """Collect timings from ``@timing`` workloads run within a ``with`` block.
+
+    Indexing the context (``ctx["workload"]``) returns the elapsed milliseconds;
+    ``records`` / ``values`` / ``methods`` expose the full record, the workload
+    return value, and the timing method keyed by workload name.
+    """
+
+    def __init__(self, torch=None, device: int = 0):
+        self._torch = torch or _torch()
+        self._device = device
+        self._timer = AcceleratorTimer(self._torch, device)
+        self._token = None
+        self.records: dict[str, TimingRecord] = {}
+        self.values: dict[str, object] = {}
+        self.methods: dict[str, str] = {}
+
+    def __enter__(self) -> "TimingContext":
+        self._token = _CURRENT_CONTEXT.set(self)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        _CURRENT_CONTEXT.reset(self._token)
+        return False
+
+    def __getitem__(self, workload: str) -> float:
+        return self.records[workload].elapsed_ms
+
+    def record(self, workload: str, fn, *args, **kwargs):
+        result = self._timer.run(fn, *args, **kwargs)
+        self.records[workload] = result
+        self.values[workload] = result.value
+        self.methods[workload] = result.method
+        return result.value
+
+
+def timing(fn):
+    """Decorate a workload so an active ``timing_context`` records its time.
+
+    When no context is active on the current thread, the wrapped function runs
+    exactly as if it were undecorated.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        ctx = _CURRENT_CONTEXT.get()
+        if ctx is None:
+            return fn(*args, **kwargs)
+        return ctx.record(fn.__name__, fn, *args, **kwargs)
+
+    return wrapper
+
+
+def timing_context(torch=None, device: int = 0) -> TimingContext:
+    """Open a context that records ``@timing`` workload calls on ``device``."""
+    return TimingContext(torch, device)
+
+
+__all__ = [
+    "timing",
+    "timing_context",
+    "TimingContext",
+    "TimingRecord",
+    "AcceleratorTimer",
+]

--- a/python/probing/timing/_cuda_runtime_ffi.py
+++ b/python/probing/timing/_cuda_runtime_ffi.py
@@ -1,0 +1,231 @@
+"""ctypes bridge for CUDA Driver stream memory operations.
+
+Used by the FFI stream-value gate. Loads ``libcuda`` directly and exposes the
+``cuStreamWaitValue32`` / ``cuStreamWriteValue32`` driver entry points so the
+host can stall and release a device-side flag without compiling anything.
+"""
+from __future__ import annotations
+
+import ctypes
+import threading
+
+_LOCK = threading.Lock()
+_RUNTIME = None
+
+CUDA_SUCCESS = 0
+CU_STREAM_WAIT_VALUE_GEQ = 0
+CU_STREAM_WRITE_VALUE_DEFAULT = 0
+CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS_V1 = 92
+
+
+def _driver_library():
+    """Load the CUDA Driver API library."""
+    for name in ("libcuda.so.1", "libcuda.so"):
+        try:
+            return ctypes.CDLL(name)
+        except OSError:
+            continue
+    raise RuntimeError("failed to load libcuda.so.1")
+
+
+def _symbol(handle, name: str, fallback: str | None = None):
+    sym = getattr(handle, name, None)
+    if sym is None and fallback is not None:
+        sym = getattr(handle, fallback, None)
+    if sym is None:
+        raise RuntimeError(f"{name} is not available in the CUDA driver library")
+    return sym
+
+
+class CudaDriverApi:
+    """Small typed wrapper around the CUDA Driver C ABI."""
+
+    def __init__(self):
+        self._lib = _driver_library()
+        self._bind()
+        self._check(self._cu_init(0), "cuInit")
+
+    def _bind(self) -> None:
+        self._cu_init = _symbol(self._lib, "cuInit")
+        self._cu_init.argtypes = [ctypes.c_uint]
+        self._cu_init.restype = ctypes.c_int
+
+        self._cu_get_error_name = _symbol(self._lib, "cuGetErrorName")
+        self._cu_get_error_name.argtypes = [
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_char_p),
+        ]
+        self._cu_get_error_name.restype = ctypes.c_int
+
+        self._cu_get_error_string = _symbol(self._lib, "cuGetErrorString")
+        self._cu_get_error_string.argtypes = [
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_char_p),
+        ]
+        self._cu_get_error_string.restype = ctypes.c_int
+
+        self._cu_device_get = _symbol(self._lib, "cuDeviceGet")
+        self._cu_device_get.argtypes = [ctypes.POINTER(ctypes.c_int), ctypes.c_int]
+        self._cu_device_get.restype = ctypes.c_int
+
+        self._cu_device_get_attribute = _symbol(self._lib, "cuDeviceGetAttribute")
+        self._cu_device_get_attribute.argtypes = [
+            ctypes.POINTER(ctypes.c_int),
+            ctypes.c_int,
+            ctypes.c_int,
+        ]
+        self._cu_device_get_attribute.restype = ctypes.c_int
+
+        self._cu_ctx_get_current = _symbol(self._lib, "cuCtxGetCurrent")
+        self._cu_ctx_get_current.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+        self._cu_ctx_get_current.restype = ctypes.c_int
+
+        self._cu_ctx_get_device = _symbol(self._lib, "cuCtxGetDevice")
+        self._cu_ctx_get_device.argtypes = [ctypes.POINTER(ctypes.c_int)]
+        self._cu_ctx_get_device.restype = ctypes.c_int
+
+        self._cu_device_primary_ctx_retain = _symbol(
+            self._lib, "cuDevicePrimaryCtxRetain"
+        )
+        self._cu_device_primary_ctx_retain.argtypes = [
+            ctypes.POINTER(ctypes.c_void_p),
+            ctypes.c_int,
+        ]
+        self._cu_device_primary_ctx_retain.restype = ctypes.c_int
+
+        self._cu_ctx_set_current = _symbol(self._lib, "cuCtxSetCurrent")
+        self._cu_ctx_set_current.argtypes = [ctypes.c_void_p]
+        self._cu_ctx_set_current.restype = ctypes.c_int
+
+        self._cu_stream_wait_value32 = _symbol(
+            self._lib, "cuStreamWaitValue32_v2", "cuStreamWaitValue32"
+        )
+        self._cu_stream_wait_value32.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+            ctypes.c_uint32,
+            ctypes.c_uint,
+        ]
+        self._cu_stream_wait_value32.restype = ctypes.c_int
+
+        self._cu_stream_write_value32 = _symbol(
+            self._lib, "cuStreamWriteValue32_v2", "cuStreamWriteValue32"
+        )
+        self._cu_stream_write_value32.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+            ctypes.c_uint32,
+            ctypes.c_uint,
+        ]
+        self._cu_stream_write_value32.restype = ctypes.c_int
+
+    def _check(self, result: int, op: str) -> None:
+        if result == CUDA_SUCCESS:
+            return
+
+        name = ctypes.c_char_p()
+        message = ctypes.c_char_p()
+        self._cu_get_error_name(result, ctypes.byref(name))
+        self._cu_get_error_string(result, ctypes.byref(message))
+
+        parts = [f"{op} failed"]
+        if name.value:
+            parts.append(name.value.decode("utf-8", "replace"))
+        parts.append(f"({result})")
+        if message.value:
+            parts.append(message.value.decode("utf-8", "replace"))
+        raise RuntimeError(": ".join(parts))
+
+    def clear_error(self) -> None:
+        """CUDA Driver calls return errors directly, so there is no sticky error."""
+
+    def set_device(self, device: int) -> None:
+        device = int(device)
+
+        current = ctypes.c_void_p()
+        self._check(
+            self._cu_ctx_get_current(ctypes.byref(current)), "cuCtxGetCurrent"
+        )
+        if current.value is not None:
+            current_device = ctypes.c_int()
+            result = self._cu_ctx_get_device(ctypes.byref(current_device))
+            if result == CUDA_SUCCESS and current_device.value == device:
+                return
+
+        cu_device = ctypes.c_int()
+        self._check(self._cu_device_get(ctypes.byref(cu_device), device), "cuDeviceGet")
+
+        primary = ctypes.c_void_p()
+        self._check(
+            self._cu_device_primary_ctx_retain(ctypes.byref(primary), cu_device.value),
+            "cuDevicePrimaryCtxRetain",
+        )
+        self._check(self._cu_ctx_set_current(primary), "cuCtxSetCurrent")
+
+    def _device_supports_stream_mem_ops(self, device: int) -> bool:
+        cu_device = ctypes.c_int()
+        self._check(self._cu_device_get(ctypes.byref(cu_device), device), "cuDeviceGet")
+
+        supported = ctypes.c_int()
+        self._check(
+            self._cu_device_get_attribute(
+                ctypes.byref(supported),
+                CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS_V1,
+                cu_device.value,
+            ),
+            "cuDeviceGetAttribute(CAN_USE_STREAM_MEM_OPS)",
+        )
+        return supported.value != 0
+
+    def wait_value32(self, stream_handle: int, ptr: int, value: int) -> None:
+        self._check(
+            self._cu_stream_wait_value32(
+                ctypes.c_void_p(int(stream_handle)),
+                ctypes.c_uint64(int(ptr)),
+                ctypes.c_uint32(int(value)),
+                ctypes.c_uint(CU_STREAM_WAIT_VALUE_GEQ),
+            ),
+            "cuStreamWaitValue32",
+        )
+
+    def write_value32(self, stream_handle: int, ptr: int, value: int) -> None:
+        self._check(
+            self._cu_stream_write_value32(
+                ctypes.c_void_p(int(stream_handle)),
+                ctypes.c_uint64(int(ptr)),
+                ctypes.c_uint32(int(value)),
+                ctypes.c_uint(CU_STREAM_WRITE_VALUE_DEFAULT),
+            ),
+            "cuStreamWriteValue32",
+        )
+
+    def can_use_stream_mem_ops(
+        self,
+        device: int,
+        stream_handle: int,
+        ptr: int,
+    ) -> bool:
+        """Probe stream memory ops on a private stream.
+
+        The write is queued before the wait, so an unsupported wait cannot leave
+        the stream blocked forever.
+        """
+        try:
+            self.set_device(device)
+            if not self._device_supports_stream_mem_ops(device):
+                return False
+            self.write_value32(stream_handle, ptr, 1)
+            self.wait_value32(stream_handle, ptr, 1)
+        except RuntimeError:
+            self.clear_error()
+            return False
+        return True
+
+
+def load() -> CudaDriverApi:
+    """Load CUDA Driver symbols once per process."""
+    global _RUNTIME
+    with _LOCK:
+        if _RUNTIME is None:
+            _RUNTIME = CudaDriverApi()
+        return _RUNTIME

--- a/python/probing/timing/backend.py
+++ b/python/probing/timing/backend.py
@@ -1,0 +1,73 @@
+"""Accelerator backend helpers used by the timing module.
+
+Only the primitives the timer needs live here: backend detection, device
+naming, and timing-event creation.
+"""
+from __future__ import annotations
+
+
+def _torch():
+    """Import ``torch`` and register the NPU backend if it is installed."""
+    import torch
+
+    try:
+        import torch_npu  # noqa: F401  (registers the npu backend if present)
+    except Exception:
+        pass
+    return torch
+
+
+def backend(torch=None) -> str:
+    """Return the active accelerator backend: ``'npu'``, ``'cuda'``, or ``'cpu'``."""
+    torch = torch or _torch()
+    if hasattr(torch, "npu") and torch.npu.is_available():
+        return "npu"
+    if torch.cuda.is_available():
+        return "cuda"
+    return "cpu"
+
+
+def dev_name(device: int) -> str:
+    """Return the ``backend:index`` string for ``device`` (``'cpu'`` on host)."""
+    bk = backend()
+    return f"{bk}:{device}" if bk != "cpu" else "cpu"
+
+
+def _accelerator_module(torch):
+    """Return the ``torch.cuda``/``torch.npu`` module, or ``None`` on CPU."""
+    bk = backend(torch)
+    if bk == "npu":
+        return torch.npu
+    if bk == "cuda":
+        return torch.cuda
+    return None
+
+
+def event_pair(torch, device):
+    """Create a ``(start, end, stream)`` timing triple on ``device``.
+
+    Returns ``None`` when the backend has no timing events (e.g. CPU), which
+    signals callers to fall back to a host-side timer.
+    """
+    accel = _accelerator_module(torch)
+    if accel is None:
+        return None
+
+    event_cls = getattr(accel, "Event", None)
+    current_stream = getattr(accel, "current_stream", None)
+    if event_cls is None or current_stream is None:
+        return None
+
+    try:
+        stream = current_stream(device)
+    except TypeError:
+        stream = current_stream()
+    return event_cls(enable_timing=True), event_cls(enable_timing=True), stream
+
+
+def record_event(event, stream) -> None:
+    """Record ``event`` on ``stream``, tolerating stream-less event APIs."""
+    try:
+        event.record(stream)
+    except TypeError:
+        event.record()

--- a/python/probing/timing/gates.py
+++ b/python/probing/timing/gates.py
@@ -1,0 +1,89 @@
+"""CUDA stream-value gate that removes host enqueue latency from timing.
+
+The gate stalls the compute stream behind a device-side flag so that the start
+event, the workload, and the end event are all enqueued before any of them run.
+The host then releases the flag, so the start->end window measures GPU execution
+time without host enqueue latency. The wait lives on a private stream that the
+compute stream waits on via an event, so the workload's own kernel launches
+never block on the host.
+
+The gate drives ``cuStreamWaitValue32`` / ``cuStreamWriteValue32`` through the
+CUDA driver via ctypes (:mod:`probing.timing._cuda_runtime_ffi`). It owns
+dedicated CUDA streams and a flag tensor, so it is built at most once per device
+and reused across measured iterations.
+"""
+from __future__ import annotations
+
+import threading
+
+from probing.timing.backend import backend, dev_name
+
+
+def _stream_handle(stream) -> int:
+    return int(stream.cuda_stream)
+
+
+class StreamValueGate:
+    """Stream-value gate backed by libcuda via ctypes FFI."""
+
+    def __init__(self, torch, device: int):
+        if backend(torch) != "cuda":
+            raise RuntimeError("StreamValueGate requires the CUDA backend")
+        self._torch = torch
+        self._device = device
+        self._flag = torch.empty((), device=dev_name(device), dtype=torch.int32)
+        self._wait_stream = torch.cuda.Stream(device=device)
+        self._release_stream = torch.cuda.Stream(device=device)
+        self._block_event = None
+
+        from probing.timing import _cuda_runtime_ffi
+
+        self._runtime = _cuda_runtime_ffi.load()
+        probe_stream = torch.cuda.Stream(device=device)
+        if not self._runtime.can_use_stream_mem_ops(
+            device, _stream_handle(probe_stream), int(self._flag.data_ptr())
+        ):
+            try:
+                probe_stream.synchronize()
+            except Exception:
+                pass
+            raise RuntimeError(
+                f"cuda:{device} does not support CUDA driver stream memory operations"
+            )
+        probe_stream.synchronize()
+
+    def reset(self, stream) -> None:
+        with self._torch.cuda.device(self._device), self._torch.cuda.stream(stream):
+            self._flag.zero_()
+        # Keep the host-side release write ordered after the reset memset.
+        stream.synchronize()
+
+    def block(self, stream, value: int = 1) -> None:
+        self._runtime.wait_value32(
+            _stream_handle(self._wait_stream), int(self._flag.data_ptr()), int(value)
+        )
+        self._block_event = self._torch.cuda.Event()
+        self._block_event.record(self._wait_stream)
+        stream.wait_event(self._block_event)
+
+    def release(self, value: int = 1) -> None:
+        self._runtime.write_value32(
+            _stream_handle(self._release_stream),
+            int(self._flag.data_ptr()),
+            int(value),
+        )
+
+
+_GATE_CACHE: dict = {}
+_GATE_CACHE_LOCK = threading.Lock()
+
+
+def acquire_gate(torch, device: int) -> StreamValueGate:
+    """Return a cached stream-value gate, building it at most once per device."""
+    key = int(device)
+    with _GATE_CACHE_LOCK:
+        gate = _GATE_CACHE.get(key)
+        if gate is None:
+            gate = StreamValueGate(torch, device)
+            _GATE_CACHE[key] = gate
+        return gate

--- a/python/probing/timing/timer.py
+++ b/python/probing/timing/timer.py
@@ -1,0 +1,56 @@
+"""Time accelerator workloads with stream-value-gated CUDA events.
+
+This is the ``cuda_event_wait_value32_ffi`` method: a stream-value gate (see
+:mod:`probing.timing.gates`) holds the start event, workload, and end event in
+the queue until the host releases a device-side flag, so the measured window
+excludes host enqueue latency. It requires a CUDA device that supports driver
+stream memory operations; there is no fallback timer.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from probing.timing.backend import event_pair, record_event
+from probing.timing.gates import acquire_gate
+
+METHOD = "cuda_event_wait_value32_ffi"
+
+
+@dataclass(frozen=True)
+class TimingRecord:
+    """One measured workload call: elapsed time, method used, and return value."""
+
+    elapsed_ms: float
+    method: str
+    value: object
+
+
+class AcceleratorTimer:
+    """Time workloads on a CUDA device using a stream-value gate."""
+
+    def __init__(self, torch, device: int):
+        self._torch = torch
+        self._device = device
+        self._gate = acquire_gate(torch, device)
+
+    @property
+    def method(self) -> str:
+        return METHOD
+
+    def run(self, fn, *args, **kwargs) -> TimingRecord:
+        """Run one workload and return its :class:`TimingRecord`."""
+        start, end, stream = event_pair(self._torch, self._device)
+        self._gate.reset(stream)
+        self._gate.block(stream)
+
+        record_event(start, stream)
+        try:
+            value = fn(*args, **kwargs)
+        except Exception:
+            self._gate.release()
+            raise
+        record_event(end, stream)
+        self._gate.release()
+        end.synchronize()
+        elapsed_ms = float(start.elapsed_time(end))
+        return TimingRecord(elapsed_ms, METHOD, value)

--- a/tests/regression/timing/test_timing_gpu.py
+++ b/tests/regression/timing/test_timing_gpu.py
@@ -1,0 +1,96 @@
+"""End-to-end timing tests that run on a real CUDA device.
+
+These drive the actual stream-value-gated CUDA-event path. They are skipped when
+no CUDA device is present (e.g. CPU-only CI) and skipped gracefully when the
+device lacks driver stream memory operations.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="requires a CUDA device"
+    ),
+]
+
+from probing.timing import TimingRecord, timing, timing_context  # noqa: E402
+
+_DEVICE = 0
+_METHOD = "cuda_event_wait_value32_ffi"
+
+
+def _warm_up(fn) -> None:
+    """Run ``fn`` once outside any gate and sync.
+
+    The stream-value gate holds the compute stream behind a device-side flag, so
+    a host-side sync the workload triggers on its first call (lazy cuBLAS init,
+    workspace allocation) would deadlock behind the still-closed gate. Real
+    profiling warms up the same way before measuring.
+    """
+    fn()
+    torch.cuda.synchronize(_DEVICE)
+
+
+def test_timing_context_measures_real_workload():
+    a = torch.randn(512, 512, device=f"cuda:{_DEVICE}")
+    b = torch.randn(512, 512, device=f"cuda:{_DEVICE}")
+
+    @timing
+    def gemm():
+        return a @ b
+
+    _warm_up(gemm)
+
+    try:
+        with timing_context(device=_DEVICE) as ctx:
+            out = gemm()
+    except RuntimeError as exc:  # pragma: no cover - driver dependent
+        pytest.skip(f"stream-value gate unavailable on cuda:{_DEVICE}: {exc}")
+
+    assert out.shape == (512, 512)
+    assert ctx["gemm"] > 0.0
+    assert ctx.methods["gemm"] == _METHOD
+    rec = ctx.records["gemm"]
+    assert isinstance(rec, TimingRecord)
+    assert rec.value is out
+
+
+def test_timing_decorator_is_noop_outside_context():
+    a = torch.randn(64, 64, device=f"cuda:{_DEVICE}")
+
+    @timing
+    def gemm():
+        return a @ a
+
+    out = gemm()  # no active context -> runs untouched, nothing recorded
+    assert out.shape == (64, 64)
+
+
+def test_timing_context_reuses_gate_across_iterations():
+    a = torch.randn(256, 256, device=f"cuda:{_DEVICE}")
+
+    @timing
+    def relu():
+        return torch.relu(a)
+
+    _warm_up(relu)
+
+    elapsed = []
+    for _ in range(5):
+        try:
+            with timing_context(device=_DEVICE) as ctx:
+                relu()
+        except RuntimeError as exc:  # pragma: no cover - driver dependent
+            pytest.skip(f"stream-value gate unavailable on cuda:{_DEVICE}: {exc}")
+        elapsed.append(ctx["relu"])
+
+    # Records are keyed by workload name, so repeated calls overwrite in place.
+    assert len(elapsed) == 5
+    assert all(ms > 0.0 for ms in elapsed)
+    assert ctx.methods["relu"] == _METHOD

--- a/tests/unit/probing/timing/test_timing_backend.py
+++ b/tests/unit/probing/timing/test_timing_backend.py
@@ -1,0 +1,135 @@
+"""Unit tests for :mod:`probing.timing.backend`.
+
+These exercise the accelerator backend helpers with lightweight fakes so they
+run without a real CUDA/NPU device.
+"""
+
+from __future__ import annotations
+
+from probing.timing import backend as backend_mod
+
+
+class _FakeAccel:
+    """Stand-in for ``torch.cuda`` / ``torch.npu``."""
+
+    def __init__(self, available=True, event_cls=None, current_stream=None):
+        self._available = available
+        if event_cls is not None:
+            self.Event = event_cls
+        if current_stream is not None:
+            self.current_stream = current_stream
+
+    def is_available(self):
+        return self._available
+
+
+class _FakeTorch:
+    """Minimal ``torch`` stand-in exposing only ``cuda`` / ``npu``."""
+
+    def __init__(self, cuda=None, npu=None):
+        if cuda is not None:
+            self.cuda = cuda
+        if npu is not None:
+            self.npu = npu
+
+
+class _FakeEvent:
+    def __init__(self, enable_timing=False):
+        self.enable_timing = enable_timing
+
+
+def test_backend_prefers_npu_when_available():
+    torch = _FakeTorch(cuda=_FakeAccel(available=True), npu=_FakeAccel(available=True))
+    assert backend_mod.backend(torch) == "npu"
+
+
+def test_backend_reports_cuda_when_no_npu():
+    torch = _FakeTorch(cuda=_FakeAccel(available=True))
+    assert backend_mod.backend(torch) == "cuda"
+
+
+def test_backend_ignores_npu_that_is_unavailable():
+    torch = _FakeTorch(cuda=_FakeAccel(available=True), npu=_FakeAccel(available=False))
+    assert backend_mod.backend(torch) == "cuda"
+
+
+def test_backend_falls_back_to_cpu():
+    torch = _FakeTorch(cuda=_FakeAccel(available=False))
+    assert backend_mod.backend(torch) == "cpu"
+
+
+def test_dev_name_uses_backend_and_index(monkeypatch):
+    monkeypatch.setattr(backend_mod, "backend", lambda torch=None: "cuda")
+    assert backend_mod.dev_name(3) == "cuda:3"
+
+
+def test_dev_name_is_plain_cpu_on_host(monkeypatch):
+    monkeypatch.setattr(backend_mod, "backend", lambda torch=None: "cpu")
+    assert backend_mod.dev_name(0) == "cpu"
+
+
+def test_event_pair_returns_none_on_cpu():
+    torch = _FakeTorch(cuda=_FakeAccel(available=False))
+    assert backend_mod.event_pair(torch, 0) is None
+
+
+def test_event_pair_returns_timing_triple_on_cuda():
+    seen = {}
+
+    def current_stream(device):
+        seen["device"] = device
+        return "STREAM"
+
+    accel = _FakeAccel(available=True, event_cls=_FakeEvent, current_stream=current_stream)
+    torch = _FakeTorch(cuda=accel)
+
+    start, end, stream = backend_mod.event_pair(torch, 5)
+
+    assert seen["device"] == 5
+    assert stream == "STREAM"
+    assert isinstance(start, _FakeEvent) and isinstance(end, _FakeEvent)
+    assert start is not end
+    assert start.enable_timing is True and end.enable_timing is True
+
+
+def test_event_pair_tolerates_stream_without_device_arg():
+    def current_stream(device=None):
+        if device is not None:
+            raise TypeError("no device arg")
+        return "DEFAULT_STREAM"
+
+    accel = _FakeAccel(available=True, event_cls=_FakeEvent, current_stream=current_stream)
+    torch = _FakeTorch(cuda=accel)
+
+    _start, _end, stream = backend_mod.event_pair(torch, 0)
+    assert stream == "DEFAULT_STREAM"
+
+
+def test_event_pair_returns_none_when_events_missing():
+    accel = _FakeAccel(available=True)  # no Event / current_stream attributes
+    torch = _FakeTorch(cuda=accel)
+    assert backend_mod.event_pair(torch, 0) is None
+
+
+def test_record_event_passes_stream():
+    calls = []
+
+    class _Event:
+        def record(self, stream):
+            calls.append(stream)
+
+    backend_mod.record_event(_Event(), "STREAM")
+    assert calls == ["STREAM"]
+
+
+def test_record_event_falls_back_without_stream_arg():
+    calls = []
+
+    class _Event:
+        def record(self, stream=None):
+            if stream is not None:
+                raise TypeError("stream not accepted")
+            calls.append("no-stream")
+
+    backend_mod.record_event(_Event(), "STREAM")
+    assert calls == ["no-stream"]

--- a/tests/unit/probing/timing/test_timing_context.py
+++ b/tests/unit/probing/timing/test_timing_context.py
@@ -1,0 +1,128 @@
+"""Unit tests for the public :mod:`probing.timing` API.
+
+These cover the ``@timing`` decorator and ``TimingContext`` bookkeeping. The
+underlying ``AcceleratorTimer`` (which needs a GPU) is replaced with a fake so
+the context/contextvar behaviour can be tested on any machine.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import probing.timing as timing_mod
+from probing.timing import TimingRecord, timing, timing_context
+
+
+class _FakeTimer:
+    """Runs the workload on the host and returns a fixed elapsed time."""
+
+    elapsed_ms = 1.5
+    method = "cuda_event_wait_value32_ffi"
+
+    def __init__(self, torch, device):
+        self.torch = torch
+        self.device = device
+
+    def run(self, fn, *args, **kwargs):
+        value = fn(*args, **kwargs)
+        return TimingRecord(self.elapsed_ms, self.method, value)
+
+
+@pytest.fixture(autouse=True)
+def _fake_timer(monkeypatch):
+    """Swap in the host-side fake timer and guarantee a clean contextvar."""
+    monkeypatch.setattr(timing_mod, "AcceleratorTimer", _FakeTimer)
+    assert timing_mod._CURRENT_CONTEXT.get() is None
+    yield
+    assert timing_mod._CURRENT_CONTEXT.get() is None
+
+
+def test_timing_runs_untouched_without_active_context():
+    calls = []
+
+    @timing
+    def workload(x):
+        calls.append(x)
+        return x * 2
+
+    assert workload(21) == 42
+    assert calls == [21]
+
+
+def test_all_exports_public_api():
+    assert set(timing_mod.__all__) == {
+        "timing",
+        "timing_context",
+        "TimingContext",
+        "TimingRecord",
+        "AcceleratorTimer",
+    }
+
+
+def test_context_records_decorated_workload():
+    @timing
+    def gemm():
+        return "result"
+
+    with timing_context(torch=object(), device=0) as ctx:
+        returned = gemm()
+
+    assert returned == "result"
+    assert ctx["gemm"] == _FakeTimer.elapsed_ms
+    assert ctx.values["gemm"] == "result"
+    assert ctx.methods["gemm"] == "cuda_event_wait_value32_ffi"
+    assert ctx.records["gemm"].elapsed_ms == _FakeTimer.elapsed_ms
+
+
+def test_decorator_forwards_args_and_kwargs():
+    @timing
+    def add(a, b, *, c):
+        return a + b + c
+
+    with timing_context(torch=object()) as ctx:
+        total = add(1, 2, c=3)
+
+    assert total == 6
+    assert ctx.values["add"] == 6
+
+
+def test_record_uses_function_name_as_key():
+    def raw():
+        return 7
+
+    with timing_context(torch=object()) as ctx:
+        value = ctx.record("custom_label", raw)
+
+    assert value == 7
+    assert "custom_label" in ctx.records
+    assert ctx["custom_label"] == _FakeTimer.elapsed_ms
+
+
+def test_context_restores_previous_on_exit():
+    @timing
+    def work():
+        return timing_mod._CURRENT_CONTEXT.get()
+
+    with timing_context(torch=object()) as outer:
+        assert timing_mod._CURRENT_CONTEXT.get() is outer
+        with timing_context(torch=object()) as inner:
+            assert timing_mod._CURRENT_CONTEXT.get() is inner
+            work()
+        # Inner block exited: the outer context must be active again.
+        assert timing_mod._CURRENT_CONTEXT.get() is outer
+        assert "work" in inner.records
+        assert "work" not in outer.records
+
+    assert timing_mod._CURRENT_CONTEXT.get() is None
+
+
+def test_workload_exception_propagates_through_context():
+    @timing
+    def boom():
+        raise RuntimeError("kernel launch failed")
+
+    with timing_context(torch=object()) as ctx:
+        with pytest.raises(RuntimeError, match="kernel launch failed"):
+            boom()
+
+    assert ctx.records == {}

--- a/tests/unit/probing/timing/test_timing_cuda_ffi.py
+++ b/tests/unit/probing/timing/test_timing_cuda_ffi.py
@@ -1,0 +1,59 @@
+"""Unit tests for :mod:`probing.timing._cuda_runtime_ffi`.
+
+Loading ``libcuda`` requires a driver, so these tests cover the pure-Python
+pieces: the symbol resolver (with its ``_v2`` fallback), the driver constants,
+and the process-wide ``load()`` singleton.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from probing.timing import _cuda_runtime_ffi as ffi
+
+
+class _FakeHandle:
+    pass
+
+
+def test_symbol_returns_named_attribute():
+    handle = _FakeHandle()
+    handle.cuStreamWaitValue32_v2 = "primary"
+    assert ffi._symbol(handle, "cuStreamWaitValue32_v2", "cuStreamWaitValue32") == "primary"
+
+
+def test_symbol_uses_fallback_when_primary_missing():
+    handle = _FakeHandle()
+    handle.cuStreamWaitValue32 = "fallback"
+    resolved = ffi._symbol(handle, "cuStreamWaitValue32_v2", "cuStreamWaitValue32")
+    assert resolved == "fallback"
+
+
+def test_symbol_raises_when_symbol_absent():
+    handle = _FakeHandle()
+    with pytest.raises(RuntimeError, match="not available in the CUDA driver library"):
+        ffi._symbol(handle, "cuMissing")
+
+
+def test_driver_constants():
+    assert ffi.CUDA_SUCCESS == 0
+    assert ffi.CU_STREAM_WAIT_VALUE_GEQ == 0
+    assert ffi.CU_STREAM_WRITE_VALUE_DEFAULT == 0
+    assert ffi.CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS_V1 == 92
+
+
+def test_load_is_process_wide_singleton(monkeypatch):
+    built = []
+
+    class _FakeApi:
+        def __init__(self):
+            built.append(object())
+
+    monkeypatch.setattr(ffi, "CudaDriverApi", _FakeApi)
+    monkeypatch.setattr(ffi, "_RUNTIME", None)
+
+    first = ffi.load()
+    second = ffi.load()
+
+    assert first is second
+    assert len(built) == 1

--- a/tests/unit/probing/timing/test_timing_gates.py
+++ b/tests/unit/probing/timing/test_timing_gates.py
@@ -1,0 +1,101 @@
+"""Unit tests for :mod:`probing.timing.gates`.
+
+The stream-value gate needs real CUDA driver stream memory ops to run, so these
+tests cover the parts that can be exercised without a device: the CUDA-backend
+guard, the stream-handle helper, and the per-device gate cache.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from probing.timing import gates
+
+
+class _FakeAccel:
+    def __init__(self, available):
+        self._available = available
+
+    def is_available(self):
+        return self._available
+
+
+class _FakeTorch:
+    def __init__(self, cuda_available):
+        self.cuda = _FakeAccel(cuda_available)
+
+
+class _FakeStream:
+    def __init__(self, handle):
+        self.cuda_stream = handle
+
+
+def test_stream_handle_reads_cuda_stream():
+    assert gates._stream_handle(_FakeStream(1234)) == 1234
+
+
+def test_stream_value_gate_requires_cuda_backend():
+    torch = _FakeTorch(cuda_available=False)
+    with pytest.raises(RuntimeError, match="requires the CUDA backend"):
+        gates.StreamValueGate(torch, 0)
+
+
+@pytest.fixture
+def _clear_gate_cache():
+    gates._GATE_CACHE.clear()
+    yield
+    gates._GATE_CACHE.clear()
+
+
+def test_acquire_gate_builds_once_per_device(monkeypatch, _clear_gate_cache):
+    built = []
+
+    class _FakeGate:
+        def __init__(self, torch, device):
+            built.append(device)
+            self.device = device
+
+    monkeypatch.setattr(gates, "StreamValueGate", _FakeGate)
+
+    torch = object()
+    first = gates.acquire_gate(torch, 0)
+    second = gates.acquire_gate(torch, 0)
+
+    assert first is second
+    assert built == [0]
+
+
+def test_acquire_gate_is_per_device(monkeypatch, _clear_gate_cache):
+    built = []
+
+    class _FakeGate:
+        def __init__(self, torch, device):
+            built.append(device)
+            self.device = device
+
+    monkeypatch.setattr(gates, "StreamValueGate", _FakeGate)
+
+    torch = object()
+    gate0 = gates.acquire_gate(torch, 0)
+    gate1 = gates.acquire_gate(torch, 1)
+
+    assert gate0 is not gate1
+    assert built == [0, 1]
+
+
+def test_acquire_gate_coerces_device_key(monkeypatch, _clear_gate_cache):
+    """``acquire_gate`` normalizes the device to ``int`` for its cache key."""
+    built = []
+
+    class _FakeGate:
+        def __init__(self, torch, device):
+            built.append(device)
+
+    monkeypatch.setattr(gates, "StreamValueGate", _FakeGate)
+
+    torch = object()
+    first = gates.acquire_gate(torch, 0)
+    second = gates.acquire_gate(torch, 0.0)  # same key after int() coercion
+
+    assert first is second
+    assert built == [0]

--- a/tests/unit/probing/timing/test_timing_timer.py
+++ b/tests/unit/probing/timing/test_timing_timer.py
@@ -1,0 +1,124 @@
+"""Unit tests for :mod:`probing.timing.timer`.
+
+``AcceleratorTimer`` orchestrates CUDA events and the stream-value gate. These
+tests replace the gate and event helpers with fakes so the ordering guarantees
+(gate reset/block -> start -> workload -> end -> release -> sync) can be checked
+without a GPU.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from probing.timing import timer as timer_mod
+from probing.timing.timer import METHOD, AcceleratorTimer, TimingRecord
+
+
+class _FakeGate:
+    def __init__(self, log):
+        self._log = log
+
+    def reset(self, stream):
+        self._log.append(("reset", stream))
+
+    def block(self, stream):
+        self._log.append(("block", stream))
+
+    def release(self):
+        self._log.append(("release", None))
+
+
+class _FakeEvent:
+    def __init__(self, name, log):
+        self._name = name
+        self._log = log
+
+    def synchronize(self):
+        self._log.append(("sync", self._name))
+
+    def elapsed_time(self, other):
+        # Log the event the method is invoked on so the ordering test can assert
+        # the real code computes ``start.elapsed_time(end)`` (not the reverse).
+        self._log.append(("elapsed_time", self._name))
+        return 2.5
+
+
+@pytest.fixture
+def _timer_env(monkeypatch):
+    """Build an ``AcceleratorTimer`` whose gate and events are fakes."""
+    log: list = []
+    gate = _FakeGate(log)
+    start = _FakeEvent("start", log)
+    end = _FakeEvent("end", log)
+    stream = "STREAM"
+
+    monkeypatch.setattr(timer_mod, "acquire_gate", lambda torch, device: gate)
+    monkeypatch.setattr(
+        timer_mod, "event_pair", lambda torch, device: (start, end, stream)
+    )
+    monkeypatch.setattr(
+        timer_mod,
+        "record_event",
+        lambda event, stream: log.append(("record", event._name, stream)),
+    )
+
+    timer = AcceleratorTimer(torch=object(), device=0)
+    return timer, log, stream
+
+
+def test_timing_record_is_frozen():
+    record = TimingRecord(1.0, "m", "v")
+    assert (record.elapsed_ms, record.method, record.value) == (1.0, "m", "v")
+    with pytest.raises(Exception):
+        record.elapsed_ms = 2.0  # type: ignore[misc]
+
+
+def test_method_property_reports_ffi_method(_timer_env):
+    timer, _log, _stream = _timer_env
+    assert timer.method == METHOD == "cuda_event_wait_value32_ffi"
+
+
+def test_run_returns_workload_value_and_elapsed(_timer_env):
+    timer, _log, _stream = _timer_env
+
+    record = timer.run(lambda a, b: a + b, 2, b=3)
+
+    assert isinstance(record, TimingRecord)
+    assert record.value == 5
+    assert record.elapsed_ms == 2.5
+    assert record.method == METHOD
+
+
+def test_run_orders_gate_and_events(_timer_env):
+    timer, log, stream = _timer_env
+
+    timer.run(lambda: "ok")
+
+    assert log == [
+        ("reset", stream),
+        ("block", stream),
+        ("record", "start", stream),
+        ("record", "end", stream),
+        ("release", None),
+        ("sync", "end"),
+        ("elapsed_time", "start"),
+    ]
+
+
+def test_run_releases_gate_when_workload_raises(_timer_env):
+    timer, log, stream = _timer_env
+
+    def boom():
+        raise ValueError("workload failed")
+
+    with pytest.raises(ValueError, match="workload failed"):
+        timer.run(boom)
+
+    # The end event is never recorded, but the gate must still be released so
+    # the compute stream does not stay blocked behind the device-side flag.
+    assert log == [
+        ("reset", stream),
+        ("block", stream),
+        ("record", "start", stream),
+        ("release", None),
+    ]


### PR DESCRIPTION
- Added the `probing.timing` package for stream-value-gated CUDA-event timing, exposing the `timing` decorator and `timing_context`, an `AcceleratorTimer`, backend detection, a per-device stream-value gate, and a ctypes CUDA-driver FFI bridge.
- Added hardware-independent unit tests under `tests/unit/probing/timing/` using fake torch/gate stand-ins: backend detection and event helpers, the gate's CUDA guard and per-device cache, `AcceleratorTimer` ordering and gate-release-on-error, the `@timing`/`TimingContext` bookkeeping and contextvar isolation, and the FFI symbol resolver, constants, and singleton loader.
- Added a CUDA-gated end-to-end regression test `tests/regression/timing/test_timing_gpu.py` exercising the stream-value-gated CUDA-event path, with a cuBLAS warm-up to avoid deadlocking behind the closed gate.