### PR TITLE
Update .gitignore, Cargo.lock, and enhance profiling documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ docs/site/
 .coverage
 .pytest_cache/
 web/target/
+frontend/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3580,10 +3580,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "signal-hook-registry",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
+ "ureq",
  "uuid",
 ]
 

--- a/docs/src/design/profiling.md
+++ b/docs/src/design/profiling.md
@@ -155,12 +155,15 @@ Profiling starts on the first `optimizer.step()` after torch is imported (optimi
 
 ### Backtrace Collection
 
-On-demand or periodic stack capture (SIGUSR2 / synchronous walk) into `python.backtrace`:
+On-demand stack capture and CPU sampling (`SIGPROF`, `probing.pprof.sample_freq`) share one stack pipeline:
 
-- Function names, file paths, line numbers
-- Python and native frames (merged where possible)
+- **Python frames:** eval-frame hook (`vm_tracer` / `PYSTACKS`) is the sole source; symbols are interned under the GIL (full path for source view, basename in flamegraph labels); signal handlers copy pointer keys only.
+- **Native frames:** `SIGPROF` and cross-thread `SIGUSR2` use the same safe handler—frame-pointer walk + POD snapshot in-signal; symbolization and Python/native merge run off-signal (best-effort, no errors propagated upward).
+- **Merge:** `stack_merge` splices Python frames at CPython eval boundaries (leaf-aligned).
+- **Reuse:** when `SIGPROF` sampling is active, the main-thread HTTP/flamegraph path reuses the latest per-thread SIGPROF snapshot when available.
+- **Main-thread HTTP path:** does not deliver `SIGUSR2` (avoids interrupting the training main thread); without SIGPROF it falls back to a synchronous `PYSTACKS` read (Python-heavy, one-shot). Cross-thread on-demand capture still uses `SIGUSR2` (dedicated to stack capture; crash grace release is HTTP-only).
 
-CPU sampling via pprof (`probing.pprof.sample_freq`) is separate from TorchProbe module hooks.
+TorchProbe module hooks are independent. The distributed flamegraph (`GET /apis/training/distributed_flamegraph/json`) currently aggregates `python.torch_trace`; cross-rank CPU mixed-mode flamegraphs should prefer the unified SIGPROF data source (cluster fan-out of folded stacks) rather than per-path merge logic.
 
 ## System Metrics
 

--- a/docs/src/design/profiling.zh.md
+++ b/docs/src/design/profiling.zh.md
@@ -157,7 +157,16 @@ configure("on,rate=0.5,layer_rate=0.3")
 
 ## Python 堆栈分析
 
-按需或周期性栈采集（SIGUSR2 / 同步 walk）写入 `python.backtrace`。CPU 采样（pprof，`probing.pprof.sample_freq`）与 TorchProbe 模块钩子相互独立。
+按需栈采集与 CPU 采样（`SIGPROF`，`probing.pprof.sample_freq`）共用同一套基础设施：
+
+- **Python 帧**：eval-frame hook（`vm_tracer` / `PYSTACKS`）是唯一数据源；符号在 GIL 下 intern（保留完整路径供源码查看，火焰图展示 basename），signal 路径只拷贝指针。
+- **C++ 帧**：`SIGPROF` 与跨线程 `SIGUSR2` 使用相同的安全 handler——仅在 signal 内做 frame-pointer walk + 拷贝 POD 快照；symbolize 与 Python/native 合并在 signal 外完成（尽力而为，不向上抛错）。
+- **合并**：`stack_merge` 在 eval 帧边界将 Python 帧拼入 native 塔（leaf 对齐）。
+- **复用**：`SIGPROF` 开启时，主线程 HTTP/火焰图路径优先复用该线程最近一次 SIGPROF 快照，避免重复 signal。
+- **主线程 HTTP 路径**：不发 `SIGUSR2`（避免中断训练主线程）；无 SIGPROF 时回退为同步读取 `PYSTACKS`（Python 帧为主，单次快照）。跨线程按需采集仍使用 `SIGUSR2`（与 crash grace 分离，grace release 仅 HTTP）。
+- **分布式火焰图**：跨 rank merge 后每个 frame 携带 `ranks`（该分区下贡献样本的 training rank）；Web 点选/缩放某个分叉时展示这些 rank。
+
+TorchProbe 模块钩子与上述栈采集相互独立。分布式 CPU 混合栈火焰图见 `GET /apis/training/distributed_stack_flamegraph/json`（Web：**Stacks → Distributed**）。旧版 torch 模块级 API `/apis/training/distributed_flamegraph/json` 仍保留。
 
 ## 系统指标
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,7 @@ Framework integration **contract tests** live under `tests/regression/ext/` (e.g
 | **`torch_probe_overhead_smoke.py`** | none | TorchProbe shadow-step overhead smoke (no GPU) |
 | **`bench_instrumentation.py`** | `torch` (optional) | One-shot report: span / phase hooks / TorchProbe overhead (`make bench`) |
 | **`run_soak.sh`** | `torch`, `torchvision` | Long-running soak (synthetic ImageNet + probing); used by CI `soak.yml` |
+| **`run_imagenet_ddp.sh`** | `torch`, `torchvision` | **默认 2-rank torchrun** DDP demo（cluster query / 分布式火焰图 / `global.python.profile_*`） |
 | **`run_megatron_soak.sh`** | `megatron-core`, CUDA | Megatron-Core torchrun soak（默认 2 GPU / TP=2，`PROBING_PORT=18080`） |
 | **`run_vllm_soak.sh`** | `vllm` / `vllm-metal` | vLLM 真实推理 soak（默认 10min，`PROBING_PORT=18081`） |
 | **`soak_assert.py`** | none (beyond probing) | Post-soak SQL / overhead assertions |
@@ -58,6 +59,10 @@ DURATION_SEC=60 ./examples/run_soak.sh
 
 # 2-rank gloo DDP (assertions on rank 0)
 NPROC=2 DIST_BACKEND=gloo DURATION_SEC=120 ./examples/run_soak.sh
+
+# dedicated distributed demo (default 2 ranks, Web UI on :18080)
+./examples/run_imagenet_ddp.sh
+DURATION_SEC=60 ./examples/run_imagenet_ddp.sh
 ```
 
 On Linux you can also attach with `probing -t <pid> inject` instead of `PROBING=1` at startup.

--- a/examples/imagenet_with_span.py
+++ b/examples/imagenet_with_span.py
@@ -233,6 +233,86 @@ def _training_device(
     return torch.device("cpu")
 
 
+def _configure_distributed_args(args) -> None:
+    """Honor ``torchrun`` env (``RANK`` / ``WORLD_SIZE`` / ``LOCAL_RANK``)."""
+    if "WORLD_SIZE" in os.environ:
+        args.world_size = int(os.environ["WORLD_SIZE"])
+    elif args.dist_url == "env://" and args.world_size == -1:
+        args.world_size = int(os.environ["WORLD_SIZE"])
+    if "RANK" in os.environ and args.rank == -1:
+        args.rank = int(os.environ["RANK"])
+    args.distributed = args.world_size > 1 or args.multiprocessing_distributed
+
+
+def _init_distributed(args, gpu: int | None, ngpus_per_node: int) -> None:
+    if not args.distributed:
+        return
+    if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
+        if args.rank == -1:
+            args.rank = int(os.environ["RANK"])
+        if args.world_size < 1:
+            args.world_size = int(os.environ["WORLD_SIZE"])
+        dist.init_process_group(backend=args.dist_backend)
+        return
+    if args.dist_url == "env://" and args.rank == -1:
+        args.rank = int(os.environ["RANK"])
+    if args.multiprocessing_distributed:
+        args.rank = args.rank * ngpus_per_node + gpu
+    dist.init_process_group(
+        backend=args.dist_backend,
+        init_method=args.dist_url,
+        world_size=args.world_size,
+        rank=args.rank,
+    )
+
+
+def _sync_probing_ddp_role() -> None:
+    if not dist.is_available() or not dist.is_initialized():
+        return
+    rank = dist.get_rank()
+    world = dist.get_world_size()
+    os.environ["DATA_PARALLEL_RANK"] = str(rank)
+    os.environ["DATA_PARALLEL_SIZE"] = str(world)
+    probing.set_role(dp=rank)
+
+
+def _is_primary_rank(args) -> bool:
+    if not args.distributed:
+        return True
+    if dist.is_available() and dist.is_initialized():
+        return dist.get_rank() == 0
+    return args.rank in (-1, 0)
+
+
+def _log_distributed_probing_banner() -> None:
+    if not dist.is_available() or not dist.is_initialized() or dist.get_rank() != 0:
+        return
+    port = os.environ.get("PROBING_PORT", "18080")
+    world = dist.get_world_size()
+    print(
+        f"=> probing distributed demo: world_size={world}  "
+        f"Web UI http://127.0.0.1:{port}/",
+        flush=True,
+    )
+    print(
+        "=> try: probing -t 127.0.0.1:"
+        f"{port} cluster nodes",
+        flush=True,
+    )
+
+
+def _per_rank_batch_size(args, *, ngpus_per_node: int, device: torch.device) -> int:
+    if not args.distributed:
+        return args.batch_size
+    if device.type == "cuda":
+        divisor = ngpus_per_node
+    elif dist.is_available() and dist.is_initialized():
+        divisor = dist.get_world_size()
+    else:
+        divisor = max(1, args.world_size)
+    return max(1, int(args.batch_size / divisor))
+
+
 def main():
     args = parser.parse_args()
 
@@ -255,10 +335,7 @@ def main():
             "disable data parallelism."
         )
 
-    if args.dist_url == "env://" and args.world_size == -1:
-        args.world_size = int(os.environ["WORLD_SIZE"])
-
-    args.distributed = args.world_size > 1 or args.multiprocessing_distributed
+    _configure_distributed_args(args)
 
     if torch.cuda.is_available():
         ngpus_per_node = torch.cuda.device_count()
@@ -292,18 +369,9 @@ def main_worker(gpu, ngpus_per_node, args):
         print(f"Use LOCAL_RANK: {local_rank} for distributed training")
 
     if args.distributed:
-        if args.dist_url == "env://" and args.rank == -1:
-            args.rank = int(os.environ["RANK"])
-        if args.multiprocessing_distributed:
-            # For multiprocessing distributed training, rank needs to be the
-            # global rank among all the processes
-            args.rank = args.rank * ngpus_per_node + gpu
-        dist.init_process_group(
-            backend=args.dist_backend,
-            init_method=args.dist_url,
-            world_size=args.world_size,
-            rank=args.rank,
-        )
+        _init_distributed(args, args.gpu, ngpus_per_node)
+        _sync_probing_ddp_role()
+        _log_distributed_probing_banner()
     # create model
     with probing.span("model.init"):
         if args.pretrained:
@@ -324,13 +392,18 @@ def main_worker(gpu, ngpus_per_node, args):
         if device.type == "cuda":
             torch.cuda.set_device(local_rank)
             model = model.to(device)
-            args.batch_size = int(args.batch_size / ngpus_per_node)
+            args.batch_size = _per_rank_batch_size(
+                args, ngpus_per_node=ngpus_per_node, device=device
+            )
             args.workers = int((args.workers + ngpus_per_node - 1) / ngpus_per_node)
             model = torch.nn.parallel.DistributedDataParallel(
                 model, device_ids=[local_rank]
             )
         else:
             model = model.to(device)
+            args.batch_size = _per_rank_batch_size(
+                args, ngpus_per_node=ngpus_per_node, device=device
+            )
             model = torch.nn.parallel.DistributedDataParallel(model)
     elif args.gpu is not None and torch.cuda.is_available():
         torch.cuda.set_device(args.gpu)
@@ -546,7 +619,7 @@ def main_worker(gpu, ngpus_per_node, args):
                     )
             probing.event("epoch.end", attributes=[{"best_acc1": float(best_acc1)}])
 
-    if args.soak_assert and (not args.distributed or args.rank == 0):
+    if args.soak_assert and _is_primary_rank(args):
         _run_soak_assert(args)
 
 

--- a/examples/run_imagenet_ddp.sh
+++ b/examples/run_imagenet_ddp.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# ImageNet synthetic training — default 2-rank DDP via torchrun + probing cluster demo.
+#
+# Exercises distributed cluster query, distributed flamegraph, and federated
+# profile_hotspot SQL (global.python.*) while training runs.
+#
+# Prerequisites:
+#   make develop
+#   uv pip install torch torchvision
+#
+# Usage:
+#   ./examples/run_imagenet_ddp.sh
+#   DURATION_SEC=60 ./examples/run_imagenet_ddp.sh
+#   NPROC=2 DIST_BACKEND=nccl ./examples/run_imagenet_ddp.sh   # needs >=2 GPUs
+#
+# While training (rank 0):
+#   http://127.0.0.1:${PROBING_PORT}/
+#
+# After a short run, try (another terminal):
+#   probing -t 127.0.0.1:${PROBING_PORT} cluster nodes
+#   probing -t 127.0.0.1:${PROBING_PORT} cluster query \
+#     "SELECT rank, bucket_kind, bucket_name, self_us FROM global.python.profile_hotspot LIMIT 20"
+#   probing -t 127.0.0.1:${PROBING_PORT} query \
+#     "SELECT rank, name, self_us FROM python.torch_trace ORDER BY self_us DESC LIMIT 10"
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+[[ -f .venv/bin/activate ]] && source .venv/bin/activate
+PYTHON="$(command -v "${PYTHON:-python}")"
+
+if ! "$PYTHON" python/probing/dev_pth.py status >/dev/null 2>&1; then
+  echo "error: dev env not ready — run: make develop" >&2
+  exit 1
+fi
+
+# Always launch via the venv interpreter. Bare ``torchrun`` on PATH often points at
+# pyenv/system Python, so worker ranks miss editable ``probing`` + site hooks.
+TORCHRUN=("$PYTHON" -m torch.distributed.run)
+
+NPROC="${NPROC:-2}"
+DIST_BACKEND="${DIST_BACKEND:-gloo}"
+DURATION_SEC="${DURATION_SEC:-120}"
+MAX_STEPS="${MAX_STEPS:-0}"
+BATCH_SIZE="${BATCH_SIZE:-64}"
+WORKERS="${WORKERS:-0}"
+PROBING_PORT="${PROBING_PORT:-18080}"
+PROBING_DATA_DIR="${PROBING_DATA_DIR:-/tmp/probing_imagenet_ddp_$$}"
+MASTER_PORT="${MASTER_PORT:-29582}"
+SOAK_ASSERT="${SOAK_ASSERT:-1}"
+MASTER_ADDR="${MASTER_ADDR:-127.0.0.1}"
+
+export MASTER_ADDR MASTER_PORT
+if [[ "$(uname -s)" == Darwin ]]; then
+  export GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-lo0}"
+fi
+
+export PROBING="${PROBING:-1}"
+export PROBING_PORT
+export PROBING_DATA_DIR
+export PROBING_TORCH_PROFILING="${PROBING_TORCH_PROFILING:-0.01,backward=on}"
+export PROBING_SAMPLE_RATE="${PROBING_SAMPLE_RATE:-1.0}"
+export PROBING_RETENTION_DAYS="${PROBING_RETENTION_DAYS:-1}"
+export SOAK_EXPECT_CLUSTER=1
+
+mkdir -p "$PROBING_DATA_DIR"
+
+# Rank 0 binds PROBING_PORT for the Web UI. A stale listener from a prior run
+# causes "Address already in use" and the UI keeps talking to the old binary.
+if command -v lsof >/dev/null 2>&1; then
+  stale_pids="$(lsof -tiTCP:"$PROBING_PORT" -sTCP:LISTEN 2>/dev/null || true)"
+  if [[ -n "$stale_pids" ]]; then
+    echo "warning: port ${PROBING_PORT} in use (PIDs: ${stale_pids//$'\n'/, }) — stopping stale listener(s)"
+  fi
+  while read -r pid; do
+    [[ -n "$pid" ]] || continue
+    kill "$pid" 2>/dev/null || true
+  done <<< "$stale_pids"
+  sleep 0.5
+  stale_pids="$(lsof -tiTCP:"$PROBING_PORT" -sTCP:LISTEN 2>/dev/null || true)"
+  while read -r pid; do
+    [[ -n "$pid" ]] || continue
+    kill -9 "$pid" 2>/dev/null || true
+  done <<< "$stale_pids"
+fi
+
+COMMON_ARGS=(
+  examples/imagenet_with_span.py
+  /tmp/imagenet-dummy
+  --dummy
+  --no-validate
+  --arch resnet18
+  --batch-size "$BATCH_SIZE"
+  --workers "$WORKERS"
+  --epochs 9999
+  --max-duration-sec "$DURATION_SEC"
+  --dist-backend "$DIST_BACKEND"
+)
+
+if [[ "$MAX_STEPS" -gt 0 ]]; then
+  COMMON_ARGS+=(--max-steps "$MAX_STEPS")
+fi
+
+if [[ "$SOAK_ASSERT" == "1" ]]; then
+  COMMON_ARGS+=(--soak-assert)
+fi
+
+if [[ "$DIST_BACKEND" == "nccl" ]]; then
+  if ! "$PYTHON" -c "import torch; assert torch.cuda.is_available()" 2>/dev/null; then
+    echo "error: nccl requires CUDA; use DIST_BACKEND=gloo on CPU/macOS" >&2
+    exit 1
+  fi
+  gpu_count="$("$PYTHON" -c 'import torch; print(torch.cuda.device_count())')"
+  if [[ "$NPROC" -gt "$gpu_count" ]]; then
+    echo "error: nccl needs >= $NPROC GPUs (found $gpu_count)" >&2
+    exit 1
+  fi
+fi
+
+echo "=== ImageNet DDP + probing (${NPROC} ranks, backend=${DIST_BACKEND}) ==="
+echo "PROBING=$PROBING  PROBING_PORT=$PROBING_PORT  PROBING_DATA_DIR=$PROBING_DATA_DIR"
+echo "python=$PYTHON"
+echo "limits: DURATION_SEC=$DURATION_SEC  MAX_STEPS=${MAX_STEPS:-0}"
+echo "Web UI (rank 0): http://127.0.0.1:${PROBING_PORT}/"
+echo
+
+"${TORCHRUN[@]}" --standalone --nproc_per_node="$NPROC" \
+  --master_addr="$MASTER_ADDR" \
+  --master_port="$MASTER_PORT" \
+  --local_addr=127.0.0.1 \
+  "${COMMON_ARGS[@]}" "$@"
+
+echo
+echo "=== training finished ==="
+echo "cluster nodes:"
+echo "  probing -t 127.0.0.1:${PROBING_PORT} cluster nodes"
+echo
+echo "distributed torch_trace (flamegraph source):"
+echo "  probing -t 127.0.0.1:${PROBING_PORT} cluster query \\"
+echo "    \"SELECT rank, name, round(self_us/1e3, 2) AS self_ms FROM global.python.torch_trace ORDER BY self_us DESC LIMIT 20\""
+echo
+echo "federated profiler SQL (after a profile capture on each rank):"
+echo "  probing -t 127.0.0.1:${PROBING_PORT} cluster query \\"
+echo "    \"SELECT rank, bucket_kind, bucket_name, self_us FROM global.python.profile_hotspot ORDER BY self_us DESC LIMIT 20\""
+echo
+echo "Web: http://127.0.0.1:${PROBING_PORT}/stacks/distributed (full) · /stacks/distributed/py (Python only)"
+echo "memtable data: $PROBING_DATA_DIR"

--- a/examples/run_soak.sh
+++ b/examples/run_soak.sh
@@ -8,6 +8,9 @@
 # Distributed (gloo on CPU, NCCL on CUDA):
 #   NPROC=2 DIST_BACKEND=gloo ./examples/run_soak.sh
 #
+# Dedicated 2-rank demo (cluster query / flamegraph / profile SQL):
+#   ./examples/run_imagenet_ddp.sh
+#
 # Env:
 #   DURATION_SEC     wall-clock cap (default 600)
 #   MAX_STEPS        optimizer-step cap (default 0 = duration only)
@@ -21,6 +24,9 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+[[ -f .venv/bin/activate ]] && source .venv/bin/activate
+PYTHON="$(command -v "${PYTHON:-python}")"
+
 DURATION_SEC="${DURATION_SEC:-600}"
 MAX_STEPS="${MAX_STEPS:-0}"
 NPROC="${NPROC:-1}"
@@ -29,6 +35,8 @@ PROBING_DATA_DIR="${PROBING_DATA_DIR:-/tmp/probing_soak_$$}"
 SOAK_ASSERT="${SOAK_ASSERT:-1}"
 BATCH_SIZE="${BATCH_SIZE:-64}"
 WORKERS="${WORKERS:-0}"
+MASTER_ADDR="${MASTER_ADDR:-127.0.0.1}"
+MASTER_PORT="${MASTER_PORT:-29581}"
 
 export PROBING="${PROBING:-1}"
 export PROBING_TORCH_PROFILING="${PROBING_TORCH_PROFILING:-on,shadow=4:1}"
@@ -38,9 +46,16 @@ export PROBING_DATA_DIR
 
 if [[ "$NPROC" -gt 1 ]]; then
   export SOAK_EXPECT_CLUSTER=1
+  export PROBING_PORT="${PROBING_PORT:-18080}"
+  export MASTER_ADDR MASTER_PORT
+  if [[ "$(uname -s)" == Darwin ]]; then
+    export GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-lo0}"
+  fi
 fi
 
 mkdir -p "$PROBING_DATA_DIR"
+
+TORCHRUN=("$PYTHON" -m torch.distributed.run)
 
 COMMON_ARGS=(
   examples/imagenet_with_span.py
@@ -67,19 +82,22 @@ echo "PROBING_DATA_DIR=$PROBING_DATA_DIR"
 echo
 
 if [[ "$NPROC" -le 1 ]]; then
-  "${PYTHON:-python}" "${COMMON_ARGS[@]}"
+  "$PYTHON" "${COMMON_ARGS[@]}"
 else
   if [[ "$DIST_BACKEND" == "nccl" ]]; then
-    if ! "${PYTHON:-python}" -c "import torch; assert torch.cuda.is_available()" 2>/dev/null; then
+    if ! "$PYTHON" -c "import torch; assert torch.cuda.is_available()" 2>/dev/null; then
       echo "nccl soak requires CUDA; set DIST_BACKEND=gloo or NPROC=1" >&2
       exit 1
     fi
-    if [[ "$NPROC" -gt 1 ]] && [[ "$(python -c 'import torch; print(torch.cuda.device_count())')" -lt "$NPROC" ]]; then
+    if [[ "$NPROC" -gt 1 ]] && [[ "$("$PYTHON" -c 'import torch; print(torch.cuda.device_count())')" -lt "$NPROC" ]]; then
       echo "nccl soak needs >= $NPROC GPUs" >&2
       exit 1
     fi
   fi
-  torchrun --standalone --nproc_per_node="$NPROC" \
+  "${TORCHRUN[@]}" --standalone --nproc_per_node="$NPROC" \
+    --master_addr="$MASTER_ADDR" \
+    --master_port="$MASTER_PORT" \
+    --local_addr=127.0.0.1 \
     "${COMMON_ARGS[@]}" \
     --dist-backend "$DIST_BACKEND"
 fi

--- a/probing/extensions/python/Cargo.toml
+++ b/probing/extensions/python/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = { workspace = true }
 sha2 = "0.10"
 uuid = { version = "1.0", features = ["v4"] }
 tokio = { workspace = true }
+ureq = { workspace = true }
 html-escape = "0.2"
 
 include_dir = "=0.7.4"
@@ -48,7 +49,6 @@ pyo3 = { version = "0.29.0", default-features = false, features = [
 # symbolization done off the signal path on a consumer thread.
 lazy_static = "1.4.0"
 async-trait = "0.1.83"
-signal-hook-registry = "1.4.2"
 regex = ">=1.6.0"
 
 [dev-dependencies]

--- a/probing/extensions/python/src/extensions/pprof.rs
+++ b/probing/extensions/python/src/extensions/pprof.rs
@@ -19,7 +19,7 @@ impl ProbeExtensionCall for PprofProbeExtension {
     async fn call(
         &self,
         path: &str,
-        _params: &HashMap<String, String>,
+        params: &HashMap<String, String>,
         _body: &[u8],
     ) -> Result<Vec<u8>, EngineError> {
         match path.trim_start_matches('/') {
@@ -27,6 +27,22 @@ impl ProbeExtensionCall for PprofProbeExtension {
                 .map(|html| html.into_bytes())
                 .map_err(|e| EngineError::CallError(e.to_string())),
             "flamegraph/json" => Ok(crate::features::pprof::flamegraph_json().into_bytes()),
+            "flamegraph/folded/json" => {
+                Ok(crate::features::pprof::folded_lines_json().into_bytes())
+            }
+            "flamegraph/distributed/json" => {
+                let cluster = params
+                    .get("cluster")
+                    .map(|v| v.as_str())
+                    .map(|v| v != "0" && v != "false")
+                    .unwrap_or(true);
+                let mode = params.get("mode").map(|s| s.as_str()).unwrap_or("mixed");
+                let (body, _) = crate::features::pprof::collect_distributed_stack_flamegraph_json(
+                    cluster, mode,
+                )
+                .await;
+                Ok(body.into_bytes())
+            }
             _ => Err(EngineError::UnsupportedCall),
         }
     }

--- a/probing/extensions/python/src/features/crash/grace.rs
+++ b/probing/extensions/python/src/features/crash/grace.rs
@@ -93,8 +93,9 @@ fn register_signals() {
     {
         use nix::sys::signal::{self, SigHandler, Signal};
         unsafe {
+            // SIGUSR1 = hold. Release is HTTP-only (`POST /apis/pythonext/crash/release`)
+            // so SIGUSR2 remains dedicated to stack capture (installed at process start).
             let _ = signal::signal(Signal::SIGUSR1, SigHandler::Handler(on_hold_signal));
-            let _ = signal::signal(Signal::SIGUSR2, SigHandler::Handler(on_release_signal));
         }
     }
 }
@@ -102,11 +103,6 @@ fn register_signals() {
 #[cfg(unix)]
 extern "C" fn on_hold_signal(_: nix::libc::c_int) {
     request_hold();
-}
-
-#[cfg(unix)]
-extern "C" fn on_release_signal(_: nix::libc::c_int) {
-    request_release(true);
 }
 
 fn hold_triggered(pid: i32) -> bool {
@@ -128,7 +124,7 @@ fn print_hold_banner(pid: i32, rank: i32) {
            attach : gdb -p {pid}\n\
            python : py-spy dump --pid {pid}\n\
            release: curl -X POST http://127.0.0.1:<port>/apis/pythonext/crash/release\n\
-                    rm {} && kill -USR2 {pid}\n",
+                    rm {}\n",
         context::hold_file_path(pid)
     );
 }

--- a/probing/extensions/python/src/features/crash/report.rs
+++ b/probing/extensions/python/src/features/crash/report.rs
@@ -142,9 +142,7 @@ fn format_event(
                 super::context::hold_file_path(event.pid)
             ));
         } else if hold_active {
-            lines.push(
-                "  hold       active — kill -USR2 or POST /apis/pythonext/crash/release".into(),
-            );
+            lines.push("  hold       active — POST /apis/pythonext/crash/release".into());
         }
     } else {
         lines.push(

--- a/probing/extensions/python/src/features/flamegraph.rs
+++ b/probing/extensions/python/src/features/flamegraph.rs
@@ -47,6 +47,8 @@ impl Default for FlamegraphOptions {
 struct Node {
     name: String,
     value: u64,
+    /// Training ranks that contributed samples under this node (distributed only).
+    ranks: std::collections::BTreeSet<i32>,
     children: Vec<Node>,
 }
 
@@ -60,6 +62,15 @@ struct PlacedFrame {
     y: f64,
     w: f64,
     depth: usize,
+    ranks: Vec<i32>,
+}
+
+/// Folded stack with sample count and contributing training ranks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttributedFoldedLine {
+    pub path: Vec<String>,
+    pub count: u64,
+    pub ranks: Vec<i32>,
 }
 
 #[derive(Debug)]
@@ -70,16 +81,33 @@ pub struct Flamegraph {
 
 impl Flamegraph {
     pub fn from_folded_lines(lines: &[String]) -> Option<Self> {
+        let attributed: Vec<AttributedFoldedLine> = lines
+            .iter()
+            .filter_map(|line| {
+                let (path, count) = parse_folded_line(line)?;
+                Some(AttributedFoldedLine {
+                    path,
+                    count,
+                    ranks: Vec::new(),
+                })
+            })
+            .collect();
+        Self::from_attributed_folded_lines(&attributed)
+    }
+
+    pub fn from_attributed_folded_lines(lines: &[AttributedFoldedLine]) -> Option<Self> {
         let mut root = Node {
             name: "all".to_string(),
             value: 0,
+            ranks: std::collections::BTreeSet::new(),
             children: Vec::new(),
         };
 
         for line in lines {
-            if let Some((path, value)) = parse_folded_line(line) {
-                insert_path(&mut root, &path, value);
+            if line.count == 0 || line.path.is_empty() {
+                continue;
             }
+            insert_path(&mut root, &line.path, line.count, &line.ranks);
         }
 
         if root.value == 0 {
@@ -339,6 +367,9 @@ fn frames_to_json(frames: &[PlacedFrame], torch: bool) -> Vec<serde_json::Value>
                 let module_path = module_path_for(f, frames);
                 obj["phase"] = json!(phase);
                 obj["modulePath"] = json!(module_path);
+            }
+            if !f.ranks.is_empty() {
+                obj["ranks"] = json!(f.ranks);
             }
             obj
         })
@@ -770,6 +801,200 @@ background:#0b0f14;color:#8b9bb4;font-family:ui-sans-serif,system-ui,sans-serif;
     }
 }
 
+/// Whether a folded segment is a per-process thread bucket (`thread-{tid}` or `thread-{tid} (name)`).
+fn is_thread_folded_segment(seg: &str) -> bool {
+    let Some(rest) = seg.strip_prefix("thread-") else {
+        return false;
+    };
+    let digit_len = rest.chars().take_while(|c| c.is_ascii_digit()).count();
+    digit_len > 0
+        && (rest.len() == digit_len
+            || matches!(rest.as_bytes().get(digit_len), Some(b' ') | Some(b'(')))
+}
+
+/// Drop root `all` and per-process `thread-*` prefixes so identical stacks merge across ranks.
+pub fn normalize_distributed_stack_folded_line(line: &str) -> Option<String> {
+    let (mut path, count) = parse_folded_line(line)?;
+    while path.first().is_some_and(|s| s == "all") {
+        path.remove(0);
+    }
+    while path.first().is_some_and(|s| is_thread_folded_segment(s)) {
+        path.remove(0);
+    }
+    if path.is_empty() {
+        return None;
+    }
+    let path = crate::features::stack_merge::canonicalize_folded_segments(&path);
+    if path.is_empty() {
+        return None;
+    }
+    Some(format!("{} {}", path.join(";"), count))
+}
+
+/// Keep only `[py] …` segments so native/C frames do not fork the flamegraph.
+pub fn filter_folded_line_python_only(line: &str) -> Option<String> {
+    let (path, count) = parse_folded_line(line)?;
+    let py_path: Vec<String> = path.into_iter().filter(|s| s.starts_with("[py]")).collect();
+    if py_path.is_empty() {
+        return None;
+    }
+    Some(format!("{} {}", py_path.join(";"), count))
+}
+
+pub fn filter_folded_lines_python_only(lines: &[String]) -> Vec<String> {
+    lines
+        .iter()
+        .filter_map(|line| filter_folded_line_python_only(line))
+        .collect()
+}
+
+/// Keep only `[py]` segments while preserving rank attribution.
+pub fn filter_attributed_folded_lines_python_only(
+    lines: &[AttributedFoldedLine],
+) -> Vec<AttributedFoldedLine> {
+    lines
+        .iter()
+        .filter_map(|line| {
+            let py_path: Vec<String> = line
+                .path
+                .iter()
+                .filter(|s| s.starts_with("[py]"))
+                .cloned()
+                .collect();
+            if py_path.is_empty() {
+                return None;
+            }
+            Some(AttributedFoldedLine {
+                path: py_path,
+                count: line.count,
+                ranks: line.ranks.clone(),
+            })
+        })
+        .collect()
+}
+
+/// Merge folded stack lines across ranks after [`normalize_distributed_stack_folded_line`].
+pub fn merge_distributed_stack_folded_line_sets(sets: &[Vec<String>]) -> Vec<String> {
+    let attributed: Vec<(Option<i32>, Vec<String>)> =
+        sets.iter().map(|lines| (None, lines.clone())).collect();
+    merge_distributed_stack_attributed(&attributed)
+        .into_iter()
+        .map(|line| format!("{} {}", line.path.join(";"), line.count))
+        .collect()
+}
+
+/// Merge per-rank folded stacks, summing counts and collecting contributing ranks.
+///
+/// `sets` entries are `(rank, folded lines)`. When `rank` is `None`, the lines still
+/// contribute to counts but are not attributed to a training rank id.
+pub fn merge_distributed_stack_attributed(
+    sets: &[(Option<i32>, Vec<String>)],
+) -> Vec<AttributedFoldedLine> {
+    use std::collections::{BTreeSet, HashMap};
+    let mut counts: HashMap<String, u64> = HashMap::new();
+    let mut ranks: HashMap<String, BTreeSet<i32>> = HashMap::new();
+    for (rank, lines) in sets {
+        for line in lines {
+            let Some(normalized) = normalize_distributed_stack_folded_line(line) else {
+                continue;
+            };
+            let Some((path, count)) = parse_folded_line(&normalized) else {
+                continue;
+            };
+            let key = path.join(";");
+            *counts.entry(key.clone()).or_insert(0) += count;
+            if let Some(r) = rank {
+                ranks.entry(key).or_default().insert(*r);
+            }
+        }
+    }
+    let mut merged: Vec<AttributedFoldedLine> = counts
+        .into_iter()
+        .filter_map(|(key, count)| {
+            let path: Vec<String> = key.split(';').map(str::to_string).collect();
+            if path.is_empty() {
+                return None;
+            }
+            let ranks = ranks
+                .remove(&key)
+                .map(|s| s.into_iter().collect())
+                .unwrap_or_default();
+            Some(AttributedFoldedLine { path, count, ranks })
+        })
+        .collect();
+    merged.sort_by(|a, b| a.path.cmp(&b.path));
+    merged
+}
+
+/// Merge folded `"stack;path count"` lines from multiple ranks; identical paths sum counts.
+pub fn merge_folded_line_sets(sets: &[Vec<String>]) -> Vec<String> {
+    use std::collections::HashMap;
+    let mut counts: HashMap<String, u64> = HashMap::new();
+    for lines in sets {
+        for line in lines {
+            if let Some((path, count)) = parse_folded_line(line) {
+                let key = path.join(";");
+                *counts.entry(key).or_insert(0) += count;
+            }
+        }
+    }
+    let mut merged: Vec<String> = counts
+        .into_iter()
+        .map(|(path, count)| format!("{path} {count}"))
+        .collect();
+    merged.sort();
+    merged
+}
+
+/// Reconstruct folded lines from a Web UI flamegraph JSON payload (leaf frames only).
+pub fn folded_lines_from_flamegraph_json(body: &str) -> Vec<String> {
+    #[derive(serde::Deserialize)]
+    struct Payload {
+        frames: Vec<Frame>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Frame {
+        id: usize,
+        parent: Option<usize>,
+        name: String,
+        value: u64,
+    }
+
+    let payload: Payload = match serde_json::from_str(body) {
+        Ok(p) => p,
+        Err(_) => return Vec::new(),
+    };
+    if payload.frames.is_empty() {
+        return Vec::new();
+    }
+    let by_id: std::collections::HashMap<usize, &Frame> =
+        payload.frames.iter().map(|f| (f.id, f)).collect();
+    let parents: std::collections::HashSet<usize> =
+        payload.frames.iter().filter_map(|f| f.parent).collect();
+    let mut lines = Vec::new();
+    for leaf in payload.frames.iter().filter(|f| !parents.contains(&f.id)) {
+        if leaf.value == 0 {
+            continue;
+        }
+        let mut path = Vec::new();
+        let mut cur = Some(leaf.id);
+        while let Some(id) = cur {
+            let Some(frame) = by_id.get(&id) else {
+                break;
+            };
+            if frame.name != "all" {
+                path.push(frame.name.clone());
+            }
+            cur = frame.parent;
+        }
+        path.reverse();
+        if !path.is_empty() {
+            lines.push(format!("{} {}", path.join(";"), leaf.value));
+        }
+    }
+    lines
+}
+
 fn parse_folded_line(line: &str) -> Option<(Vec<String>, u64)> {
     let line = line.trim();
     if line.is_empty() {
@@ -791,21 +1016,25 @@ fn parse_folded_line(line: &str) -> Option<(Vec<String>, u64)> {
     Some((frames, count))
 }
 
-fn insert_path(node: &mut Node, path: &[String], value: u64) {
+fn insert_path(node: &mut Node, path: &[String], value: u64, ranks: &[i32]) {
     node.value += value;
+    for &r in ranks {
+        node.ranks.insert(r);
+    }
     if path.is_empty() {
         return;
     }
     let head = &path[0];
     if let Some(child) = node.children.iter_mut().find(|c| c.name == *head) {
-        insert_path(child, &path[1..], value);
+        insert_path(child, &path[1..], value, ranks);
     } else {
         let mut child = Node {
             name: head.clone(),
             value: 0,
+            ranks: std::collections::BTreeSet::new(),
             children: Vec::new(),
         };
-        insert_path(&mut child, &path[1..], value);
+        insert_path(&mut child, &path[1..], value, ranks);
         node.children.push(child);
     }
 }
@@ -837,6 +1066,7 @@ fn layout_node(
         y,
         w: width,
         depth,
+        ranks: node.ranks.iter().copied().collect(),
     });
 
     if node.value == 0 || width < MIN_RENDER_WIDTH {
@@ -870,6 +1100,117 @@ fn layout_node(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn filter_folded_line_python_only_strips_native() {
+        let out = filter_folded_line_python_only(
+            "[py] train (a.py:1);_PyObject_Vectorcall;[py] forward (b.py:2) 4",
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "[py] train (a.py:1);[py] forward (b.py:2) 4".to_string()
+        );
+    }
+
+    #[test]
+    fn merge_distributed_stacks_canonicalizes_interpreter_prefix() {
+        let merged = merge_distributed_stack_folded_line_sets(&[
+            vec![
+                "[py] <module> (imagenet_with_span.py:1);[py] train (imagenet_with_span.py:659) 2"
+                    .to_string(),
+            ],
+            vec![
+                "_Py_RunMain;_pymain_run_file;[py] <module> (imagenet_with_span.py:1);[py] train (imagenet_with_span.py:659) 1"
+                    .to_string(),
+            ],
+        ]);
+        assert_eq!(
+            merged,
+            vec![
+                "[py] <module> (imagenet_with_span.py:1);[py] train (imagenet_with_span.py:659) 3"
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_distributed_stacks_strips_thread_prefix_across_ranks() {
+        let merged = merge_distributed_stack_folded_line_sets(&[
+            vec!["thread-100;[py] main (train.py:1) 3".to_string()],
+            vec!["thread-200;[py] main (train.py:1) 2".to_string()],
+        ]);
+        assert_eq!(merged, vec!["[py] main (train.py:1) 5".to_string()]);
+    }
+
+    #[test]
+    fn merge_distributed_attributed_collects_ranks_per_path() {
+        let merged = merge_distributed_stack_attributed(&[
+            (
+                Some(0),
+                vec!["thread-1;[py] main (a.py:1);[py] train (a.py:2) 2".to_string()],
+            ),
+            (
+                Some(1),
+                vec!["thread-2;[py] main (a.py:1);[py] train (a.py:2) 3".to_string()],
+            ),
+            (
+                Some(1),
+                vec!["thread-3;[py] platform;[py] train (a.py:2) 1".to_string()],
+            ),
+        ]);
+        let shared = merged
+            .iter()
+            .find(|l| l.path == ["[py] main (a.py:1)", "[py] train (a.py:2)"])
+            .expect("shared path");
+        assert_eq!(shared.count, 5);
+        assert_eq!(shared.ranks, vec![0, 1]);
+
+        let fork = merged
+            .iter()
+            .find(|l| l.path == ["[py] platform", "[py] train (a.py:2)"])
+            .expect("fork path");
+        assert_eq!(fork.count, 1);
+        assert_eq!(fork.ranks, vec![1]);
+
+        let json = Flamegraph::from_attributed_folded_lines(&merged)
+            .unwrap()
+            .json_payload(&FlamegraphOptions {
+                title: "T".to_string(),
+                count_name: "samples".to_string(),
+                kind: FlamegraphKind::Classic,
+                subtitle: String::new(),
+                metric: None,
+                profile: Some("cpu-stack-distributed".to_string()),
+            });
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let frames = v["frames"].as_array().unwrap();
+        let platform = frames
+            .iter()
+            .find(|f| f["name"] == "[py] platform")
+            .expect("platform frame");
+        assert_eq!(platform["ranks"], json!([1]));
+        let shared_frame = frames
+            .iter()
+            .find(|f| f["name"] == "[py] main (a.py:1)")
+            .expect("main frame");
+        assert_eq!(shared_frame["ranks"], json!([0, 1]));
+    }
+
+    #[test]
+    fn folded_lines_from_json_skips_all_root() {
+        let json = Flamegraph::from_folded_lines(&["thread-1;leaf 4".to_string()])
+            .unwrap()
+            .json_payload(&FlamegraphOptions {
+                title: "T".to_string(),
+                count_name: "samples".to_string(),
+                kind: FlamegraphKind::Classic,
+                subtitle: String::new(),
+                metric: None,
+                profile: Some("cpu-stack-distributed".to_string()),
+            });
+        let lines = folded_lines_from_flamegraph_json(&json);
+        assert_eq!(lines, vec!["thread-1;leaf 4".to_string()]);
+    }
 
     #[test]
     fn parse_folded_line_splits_stack_and_count() {

--- a/probing/extensions/python/src/features/mod.rs
+++ b/probing/extensions/python/src/features/mod.rs
@@ -8,7 +8,11 @@ pub mod pprof;
 pub mod py_result;
 pub mod python_api;
 pub mod spy;
-/// Native stack capture, Python/native merge, and signal handling (`SIGUSR2`).
+/// Async-signal-safe raw stack snapshotting (SIGPROF / SIGUSR2).
+pub mod stack_capture;
+/// Unified Python / native stack merge.
+pub mod stack_merge;
+/// On-demand stack capture (`SIGUSR2`) and synchronous walks.
 pub mod stack_tracer;
 pub mod torch;
 pub mod tracing;

--- a/probing/extensions/python/src/features/pprof.rs
+++ b/probing/extensions/python/src/features/pprof.rs
@@ -1,34 +1,13 @@
 //! CPU profiling via `SIGPROF` sampling ("model two": trigger in-signal, process
 //! off-signal).
 //!
-//! `setitimer(ITIMER_PROF)` delivers `SIGPROF` to whichever thread is burning
-//! CPU (the timer counts process CPU time, so samples are CPU-weighted). The
-//! signal handler is kept strictly minimal and async-signal-safe: it only
-//!   * reads the interrupted thread's `pc`/`fp` from the `ucontext`,
-//!   * walks the frame-pointer chain collecting raw return addresses,
-//!   * snapshots this thread's thread-local `PYSTACKS` (raw `usize` pointers),
-//!   * and copies that fixed-size POD snapshot into a preallocated lock-free ring
-//!     buffer. No allocation, no locks, no symbolization, no `libunwind`, no libc
-//!     string calls happen in the handler — that is what crashed the old `pprof`
-//!     path on PyTorch (libunwind + `strlen` over Accelerate/JIT frames).
-//!
-//! A dedicated consumer thread drains the ring and does all the dangerous work
-//! off the signal path: symbolizing native addresses (`backtrace::resolve`) and
-//! resolving Python `RawCallLocation`s into file/func/line. It then produces a
-//! true mixed-mode stack by splicing each Python frame into its interpreter eval
-//! frame (`_PyEval_EvalFrameDefault`) position in the native stack — the eval
-//! frames and `PYSTACKS` come from the same eval-hook calls, so they align
-//! one-to-one. Folded counts are rendered as interactive HTML by `flamegraph()`.
-//!
-//! Native caveat (accepted tradeoff): frame-pointer walking is unreliable when
-//! libraries omit frame pointers (BLAS/OpenMP); such stacks are truncated, and a
-//! `fp` that is plausible-but-unmapped can still fault inside the handler. The
-//! walk validates alignment / monotonicity / canonical range to minimize this.
+//! Raw capture and Python/native merge live in [`stack_capture`] /
+//! [`stack_merge`]; this module owns the ring buffer, timer, and folded output.
 
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
-use std::sync::atomic::{compiler_fence, AtomicBool, AtomicPtr, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Mutex, RwLock};
+use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, AtomicUsize, Ordering};
+use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
 
@@ -39,58 +18,15 @@ use once_cell::sync::Lazy;
 use serde_json::json;
 
 use crate::features::flamegraph::{FlamegraphKind, FlamegraphOptions};
-use crate::features::spy::call::RawCallLocation;
-use crate::features::spy::spy_tls_addrs;
+use crate::features::stack_capture::{self, RawStackSnapshot};
 
 const DEFAULT_SAMPLE_FREQ: i32 = 100;
 const MIN_SAMPLE_FREQ: i32 = 1;
-// Upper bound is intentionally high to allow stress testing the sampler.
 const MAX_SAMPLE_FREQ: i32 = 100_000;
 
-/// Ring capacity (power of two) and per-sample depth limits. Kept small enough
-/// that a `RawSample` (and the whole ring) stays cheap to construct/copy.
 const RING_SIZE: usize = 512;
 const RING_MASK: usize = RING_SIZE - 1;
-const MAX_NATIVE: usize = 48;
-const MAX_PY: usize = 128;
-
-/// Max number of Python threads we track for signal-safe TLS access.
-const REG_SIZE: usize = 1024;
-
-/// Upper bound on distinct folded stacks kept in the aggregate map. Protects
-/// against unbounded memory under high-frequency / high-cardinality workloads;
-/// samples for new stacks beyond this are counted as dropped.
 const MAX_FOLDED_STACKS: usize = 1 << 17;
-
-// ---------------------------------------------------------------------------
-// Raw sample (fixed-size POD, memcpy-able from the signal handler)
-// ---------------------------------------------------------------------------
-
-#[derive(Clone, Copy)]
-struct RawSample {
-    tid: u64,
-    native_len: u32,
-    py_len: u32,
-    /// Native return addresses, leaf -> root.
-    native: [usize; MAX_NATIVE],
-    /// Callee `PyCodeObject` pointers, outermost -> innermost (natural `PYSTACKS`
-    /// order). Only the pointer is captured here — it is the interner key the
-    /// consumer resolves to a label — keeping the POD sample small and cheap to
-    /// memcpy from the signal handler.
-    py: [usize; MAX_PY],
-}
-
-impl RawSample {
-    fn zeroed() -> Self {
-        RawSample {
-            tid: 0,
-            native_len: 0,
-            py_len: 0,
-            native: [0usize; MAX_NATIVE],
-            py: [0usize; MAX_PY],
-        }
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Lock-free bounded MPMC ring (Vyukov). Async-signal-safe producer side.
@@ -98,7 +34,7 @@ impl RawSample {
 
 struct Cell {
     seq: AtomicUsize,
-    data: UnsafeCell<RawSample>,
+    data: UnsafeCell<RawStackSnapshot>,
 }
 
 struct Ring {
@@ -116,7 +52,7 @@ impl Ring {
         for i in 0..RING_SIZE {
             v.push(Cell {
                 seq: AtomicUsize::new(i),
-                data: UnsafeCell::new(RawSample::zeroed()),
+                data: UnsafeCell::new(RawStackSnapshot::zeroed()),
             });
         }
         Ring {
@@ -126,8 +62,7 @@ impl Ring {
         }
     }
 
-    /// Producer (signal handler). Returns false if the ring is full.
-    fn enqueue(&self, sample: &RawSample) -> bool {
+    fn enqueue(&self, sample: &RawStackSnapshot) -> bool {
         let mut pos = self.enqueue_pos.load(Ordering::Relaxed);
         loop {
             let cell = &self.buffer[pos & RING_MASK];
@@ -151,8 +86,7 @@ impl Ring {
         }
     }
 
-    /// Consumer (sampler thread). Returns false if the ring is empty.
-    fn dequeue(&self, out: &mut RawSample) -> bool {
+    fn dequeue(&self, out: &mut RawStackSnapshot) -> bool {
         let mut pos = self.dequeue_pos.load(Ordering::Relaxed);
         loop {
             let cell = &self.buffer[pos & RING_MASK];
@@ -179,209 +113,11 @@ impl Ring {
 
 static RING_PTR: AtomicPtr<Ring> = AtomicPtr::new(std::ptr::null_mut());
 static DROPPED: AtomicU64 = AtomicU64::new(0);
-
-// ---------------------------------------------------------------------------
-// Python-thread registry: lets the handler know a thread's `PYSTACKS` TLS is
-// already allocated (touched by `rust_eval_frame`) and thus safe to read.
-// ---------------------------------------------------------------------------
-
-/// Per-thread registry entry. We store the *resolved* addresses of the thread's
-/// thread-local `PYSTACKS` / `PYSTACK_WRITING` here, captured from normal
-/// (non-signal) context in the eval hook. The signal handler then reads those
-/// raw pointers directly and NEVER touches TLS / `tlv_get_addr` itself — on
-/// macOS, accessing a thread-local from a signal handler can deadlock against
-/// dyld's loader lock when the interrupted thread was mid dlopen / lazy-bind /
-/// TLS initialization (the classic in-process sampler hang).
-struct ThreadSlot {
-    tid: AtomicU64, // 0 == empty
-    pystacks: AtomicPtr<Vec<RawCallLocation>>,
-    writing: AtomicPtr<bool>,
-    /// Inclusive-exclusive stack bounds `[lo, hi)` captured in normal context,
-    /// so the handler can validate frame-pointer reads against real mapped
-    /// stack memory. `hi == 0` means "unknown" (fall back to heuristics).
-    stack_lo: AtomicUsize,
-    stack_hi: AtomicUsize,
-}
-
-static REG_TABLE: [ThreadSlot; REG_SIZE] = [const {
-    ThreadSlot {
-        tid: AtomicU64::new(0),
-        pystacks: AtomicPtr::new(std::ptr::null_mut()),
-        writing: AtomicPtr::new(std::ptr::null_mut()),
-        stack_lo: AtomicUsize::new(0),
-        stack_hi: AtomicUsize::new(0),
-    }
-}; REG_SIZE];
-
-static REG_FULL_WARNED: AtomicBool = AtomicBool::new(false);
-
-thread_local! {
-    static THREAD_REGISTERED: std::cell::UnsafeCell<bool> = const { std::cell::UnsafeCell::new(false) };
-}
-
-/// Open-addressing probe start for `tid` (Fibonacci hashing). REG_SIZE is a
-/// power of two so the mask is exact.
-#[inline]
-fn slot_hash(tid: u64) -> usize {
-    let h = tid.wrapping_mul(0x9E37_79B9_7F4A_7C15);
-    (h >> 40) as usize & (REG_SIZE - 1)
-}
-
-/// OS-thread names captured at registration (normal context), keyed by tid, so
-/// the consumer can label thread root frames readably.
-static THREAD_NAMES: Lazy<RwLock<HashMap<u64, String>>> = Lazy::new(|| RwLock::new(HashMap::new()));
-
-/// Read the calling thread's name via `pthread_getname_np`. Normal context only.
-fn current_thread_name() -> Option<String> {
-    let mut buf = [0 as libc::c_char; 64];
-    let rc = unsafe { libc::pthread_getname_np(libc::pthread_self(), buf.as_mut_ptr(), buf.len()) };
-    if rc != 0 {
-        return None;
-    }
-    let name = unsafe { std::ffi::CStr::from_ptr(buf.as_ptr()) }
-        .to_string_lossy()
-        .into_owned();
-    if name.is_empty() {
-        None
-    } else {
-        Some(name)
-    }
-}
-
-fn thread_name(tid: u64) -> Option<String> {
-    THREAD_NAMES.read().ok().and_then(|m| m.get(&tid).cloned())
-}
-
-/// Stack bounds `[lo, hi)` of the calling thread. Safe to call only in normal
-/// context (uses `pthread_*` that may allocate / read `/proc` on Linux).
-fn current_stack_bounds() -> (usize, usize) {
-    #[cfg(target_os = "macos")]
-    unsafe {
-        let pt = libc::pthread_self();
-        let base = libc::pthread_get_stackaddr_np(pt) as usize; // highest address
-        let size = libc::pthread_get_stacksize_np(pt);
-        (base.saturating_sub(size), base)
-    }
-    #[cfg(target_os = "linux")]
-    unsafe {
-        let mut attr: libc::pthread_attr_t = std::mem::zeroed();
-        if libc::pthread_getattr_np(libc::pthread_self(), &mut attr) != 0 {
-            return (0, 0);
-        }
-        let mut addr: *mut c_void = std::ptr::null_mut();
-        let mut size: libc::size_t = 0;
-        let ok = libc::pthread_attr_getstack(&attr, &mut addr, &mut size) == 0;
-        libc::pthread_attr_destroy(&mut attr);
-        if ok {
-            let lo = addr as usize;
-            (lo, lo + size)
-        } else {
-            (0, 0)
-        }
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    {
-        (0, 0)
-    }
-}
-
-/// Called from the eval-frame hook (TLS-safe context) on every frame; the
-/// thread-local fast path makes the global table insert happen once per thread.
-pub fn register_python_thread() {
-    let already = THREAD_REGISTERED.with(|flag| unsafe {
-        if *flag.get() {
-            return true;
-        }
-        *flag.get() = true;
-        false
-    });
-    if already {
-        return;
-    }
-    let tid = current_tid();
-    // Resolve this thread's TLS addresses and stack bounds here, in normal
-    // context (none of this is async-signal-safe).
-    let (ps, wr) = spy_tls_addrs();
-    let (lo, hi) = current_stack_bounds();
-
-    if let Some(name) = current_thread_name() {
-        if let Ok(mut m) = THREAD_NAMES.write() {
-            m.insert(tid, name); // overwrite handles tid reuse
-        }
-    }
-
-    let publish = |slot: &ThreadSlot| {
-        slot.stack_lo.store(lo, Ordering::Release);
-        slot.stack_hi.store(hi, Ordering::Release);
-        slot.pystacks.store(ps, Ordering::Release);
-        slot.writing.store(wr, Ordering::Release);
-    };
-
-    let start = slot_hash(tid);
-    for i in 0..REG_SIZE {
-        let slot = &REG_TABLE[(start + i) & (REG_SIZE - 1)];
-        let v = slot.tid.load(Ordering::Acquire);
-        if v == tid {
-            // Refresh: handles tid reuse after a previous thread with the same
-            // id exited (its TLS pointers / bounds are now stale).
-            publish(slot);
-            return;
-        }
-        if v == 0
-            && slot
-                .tid
-                .compare_exchange(0, tid, Ordering::AcqRel, Ordering::Acquire)
-                .is_ok()
-        {
-            publish(slot);
-            return;
-        }
-        // Slot taken by another tid (lost the race or different thread): keep
-        // probing the same linear sequence.
-    }
-
-    if !REG_FULL_WARNED.swap(true, Ordering::Relaxed) {
-        log::warn!(
-            "probing: pprof thread registry full ({REG_SIZE} threads); \
-             Python stacks for further threads will be missing"
-        );
-    }
-}
-
-/// Find the registry slot for `tid`, or `None` if this thread never ran the eval
-/// hook. Open-addressing lookup: an empty slot in the probe sequence proves the
-/// tid is absent (entries are never deleted).
-fn thread_slot(tid: u64) -> Option<&'static ThreadSlot> {
-    let start = slot_hash(tid);
-    for i in 0..REG_SIZE {
-        let slot = &REG_TABLE[(start + i) & (REG_SIZE - 1)];
-        let v = slot.tid.load(Ordering::Acquire);
-        if v == tid {
-            return Some(slot);
-        }
-        if v == 0 {
-            return None;
-        }
-    }
-    None
-}
-
-// ---------------------------------------------------------------------------
-// Signal handler (async-signal-safe)
-// ---------------------------------------------------------------------------
-
 static SAMPLER_ENABLED: AtomicBool = AtomicBool::new(false);
-
-/// Number of signal handlers currently executing past the enabled/ring checks.
-/// `reset` uses this to quiesce before freeing the ring.
 static HANDLER_ACTIVE: AtomicUsize = AtomicUsize::new(0);
-
-/// Whether *we* enabled the eval tracer (vs. the user enabling it independently);
-/// if so, `reset` disables it again.
 static PPROF_OWNS_TRACER: AtomicBool = AtomicBool::new(false);
+static HANDLER_INSTALLED: AtomicBool = AtomicBool::new(false);
 
-/// RAII guard that marks a handler as in-flight for the duration of its body,
-/// covering all early-return paths.
 struct ActiveGuard;
 impl ActiveGuard {
     #[inline]
@@ -397,113 +133,11 @@ impl Drop for ActiveGuard {
     }
 }
 
-#[inline]
-fn current_tid() -> u64 {
-    #[cfg(target_os = "linux")]
-    unsafe {
-        libc::syscall(libc::SYS_gettid) as u64
-    }
-    #[cfg(target_os = "macos")]
-    {
-        let mut t: u64 = 0;
-        unsafe { libc::pthread_threadid_np(0, &mut t) };
-        t
-    }
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    {
-        0
-    }
-}
-
-#[inline]
-fn plausible(p: usize) -> bool {
-    // Canonical lower-half userspace pointer, above the first page.
-    (0x1000..0x0001_0000_0000_0000).contains(&p)
-}
-
-/// Extract (pc, fp) from the signal `ucontext` for the interrupted thread.
-#[allow(unused_variables)]
-unsafe fn regs_from_uctx(uctx: *mut c_void) -> (usize, usize) {
-    if uctx.is_null() {
-        return (0, 0);
-    }
-    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    {
-        let uc = uctx as *const libc::ucontext_t;
-        let mc = &(*uc).uc_mcontext;
-        let pc = mc.gregs[libc::REG_RIP as usize] as usize;
-        let fp = mc.gregs[libc::REG_RBP as usize] as usize;
-        (pc, fp)
-    }
-    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
-    {
-        let uc = uctx as *const libc::ucontext_t;
-        let mc = &(*uc).uc_mcontext;
-        (mc.pc as usize, mc.regs[29] as usize)
-    }
-    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-    {
-        let uc = uctx as *const libc::ucontext_t;
-        let ss = &(*(*uc).uc_mcontext).__ss;
-        (ss.__rip as usize, ss.__rbp as usize)
-    }
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    {
-        let uc = uctx as *const libc::ucontext_t;
-        let ss = &(*(*uc).uc_mcontext).__ss;
-        (ss.__pc as usize, ss.__fp as usize)
-    }
-    #[cfg(not(any(
-        all(target_os = "linux", target_arch = "x86_64"),
-        all(target_os = "linux", target_arch = "aarch64"),
-        all(target_os = "macos", target_arch = "x86_64"),
-        all(target_os = "macos", target_arch = "aarch64"),
-    )))]
-    {
-        (0, 0)
-    }
-}
-
-/// Walk the frame-pointer chain, collecting return addresses leaf -> root.
-/// Both x86_64 and aarch64 use the layout `[fp] = saved fp`, `[fp+8] = ret`.
-///
-/// `[lo, hi)` are the thread's stack bounds when known (`hi != 0`); reads are
-/// then proven to stay inside mapped stack memory, eliminating the residual
-/// "plausible but unmapped `fp`" fault. When bounds are unknown we fall back to
-/// alignment / monotonicity / canonical-range heuristics only.
-unsafe fn walk_frame_pointers(start_fp: usize, out: &mut [usize], lo: usize, hi: usize) -> usize {
-    let bounded = hi != 0 && lo < hi;
-    let in_stack =
-        |fp: usize| !bounded || (fp >= lo && fp + 2 * std::mem::size_of::<usize>() <= hi);
-
-    let mut fp = start_fp;
-    let mut count = 0usize;
-    while count < out.len() {
-        if !plausible(fp) || (fp & 0x7) != 0 || !in_stack(fp) {
-            break;
-        }
-        let saved_fp = *(fp as *const usize);
-        let ret = *((fp + std::mem::size_of::<usize>()) as *const usize);
-        if !plausible(ret) {
-            break;
-        }
-        out[count] = ret;
-        count += 1;
-        // Frame pointers must strictly increase by a bounded step.
-        if saved_fp <= fp || saved_fp - fp > 0x20_0000 {
-            break;
-        }
-        fp = saved_fp;
-    }
-    count
-}
-
 #[cfg(unix)]
 unsafe extern "C" fn sigprof_handler(_sig: c_int, _info: *mut libc::siginfo_t, uctx: *mut c_void) {
     if !SAMPLER_ENABLED.load(Ordering::Acquire) {
         return;
     }
-    // Mark in-flight before touching the ring so `reset` can quiesce safely.
     let _active = ActiveGuard::new();
     let ring = RING_PTR.load(Ordering::Acquire);
     if ring.is_null() {
@@ -511,63 +145,15 @@ unsafe extern "C" fn sigprof_handler(_sig: c_int, _info: *mut libc::siginfo_t, u
     }
     let ring = &*ring;
 
-    let mut sample = RawSample::zeroed();
-    sample.tid = current_tid();
-
-    // Resolve the registry slot once: its stack bounds guard the native walk and
-    // its TLS pointers feed the Python snapshot.
-    let slot = thread_slot(sample.tid);
-    let (lo, hi) = match slot {
-        Some(s) => (
-            s.stack_lo.load(Ordering::Acquire),
-            s.stack_hi.load(Ordering::Acquire),
-        ),
-        None => (0, 0),
-    };
-
-    // ---- native ----
-    let (pc, fp) = regs_from_uctx(uctx);
-    let mut nlen = 0usize;
-    if plausible(pc) {
-        sample.native[nlen] = pc;
-        nlen += 1;
-    }
-    if nlen < MAX_NATIVE {
-        nlen += walk_frame_pointers(fp, &mut sample.native[nlen..], lo, hi);
-    }
-    sample.native_len = nlen as u32;
-
-    // ---- python: read this thread's PYSTACKS through the pre-resolved raw
-    // pointers in the registry, never touching TLS / tlv_get_addr from here ----
-    if let Some(slot) = slot {
-        let wr = slot.writing.load(Ordering::Acquire);
-        let ps = slot.pystacks.load(Ordering::Acquire);
-        if !wr.is_null() && !ps.is_null() && !*wr {
-            compiler_fence(Ordering::SeqCst);
-            let stacks = &*ps;
-            let n = stacks.len().min(MAX_PY);
-            for (i, stack) in stacks.iter().enumerate().take(n) {
-                sample.py[i] = stack.callee();
-            }
-            compiler_fence(Ordering::SeqCst);
-            // If the eval hook touched PYSTACKS during the copy, discard it.
-            sample.py_len = if *wr { 0 } else { n as u32 };
-        }
-    }
-
-    if sample.native_len == 0 && sample.py_len == 0 {
+    let snapshot = stack_capture::capture_raw_snapshot(uctx);
+    if snapshot.is_empty() {
         return;
     }
-    if !ring.enqueue(&sample) {
+    stack_capture::store_latest_snapshot(&snapshot);
+    if !ring.enqueue(&snapshot) {
         DROPPED.fetch_add(1, Ordering::Relaxed);
     }
 }
-
-// ---------------------------------------------------------------------------
-// Timer + handler installation
-// ---------------------------------------------------------------------------
-
-static HANDLER_INSTALLED: AtomicBool = AtomicBool::new(false);
 
 #[cfg(unix)]
 fn install_handler() {
@@ -576,8 +162,7 @@ fn install_handler() {
     }
     unsafe {
         let mut sa: libc::sigaction = std::mem::zeroed();
-        let handler_ptr = sigprof_handler as *const () as usize;
-        sa.sa_sigaction = handler_ptr;
+        sa.sa_sigaction = sigprof_handler as *const () as usize;
         sa.sa_flags = libc::SA_SIGINFO | libc::SA_RESTART;
         libc::sigemptyset(&mut sa.sa_mask);
         libc::sigaction(libc::SIGPROF, &sa, std::ptr::null_mut());
@@ -613,10 +198,6 @@ fn disarm_timer() {
 #[cfg(not(unix))]
 fn disarm_timer() {}
 
-// ---------------------------------------------------------------------------
-// Consumer thread: symbolize + fold (all off the signal path)
-// ---------------------------------------------------------------------------
-
 struct SamplerState {
     generation: AtomicU64,
     samples: Mutex<HashMap<String, u64>>,
@@ -627,192 +208,33 @@ static SAMPLER: Lazy<SamplerState> = Lazy::new(|| SamplerState {
     samples: Mutex::new(HashMap::new()),
 });
 
-fn symbolize_native(addr: usize, cache: &mut HashMap<usize, String>) -> String {
-    if let Some(name) = cache.get(&addr) {
-        return name.clone();
-    }
-    let mut resolved: Option<String> = None;
-    backtrace::resolve(addr as *mut c_void, |sym| {
-        if resolved.is_none() {
-            if let Some(name) = sym.name() {
-                // `SymbolName`'s Display demangles Rust and C++ names.
-                resolved = Some(name.to_string());
-            }
-        }
-    });
-    let name = resolved.unwrap_or_else(|| format!("0x{addr:x}"));
-    cache.insert(addr, name.clone());
-    name
-}
-
-/// Interner mapping a callee `PyCodeObject` pointer to its formatted frame label.
-///
-/// Entries are produced eagerly in the eval hook (`intern_py_frame`), where the
-/// code object is alive under the GIL. The sampler consumer thread only ever
-/// *looks up* labels here by integer pointer key — it never dereferences a
-/// Python object — so a frame whose code object has since been freed (e.g.
-/// `torch.compile` churn) can no longer cause a use-after-free.
-static PY_SYMBOLS: Lazy<RwLock<HashMap<usize, String>>> = Lazy::new(|| RwLock::new(HashMap::new()));
-
-/// Soft cap so heavy dynamic-codegen workloads can't grow the interner forever.
-const PY_SYMBOLS_CAP: usize = 1 << 18;
-
-/// Resolve and cache a Python frame's label. MUST be called from a normal
-/// (GIL-holding) context such as the eval hook, where `loc.callee()` is alive.
-pub fn intern_py_frame(loc: &RawCallLocation) {
-    let key = loc.callee();
-    if key == 0 {
-        return;
-    }
-    if let Ok(g) = PY_SYMBOLS.read() {
-        if g.contains_key(&key) {
+fn process_sample(
+    s: &RawStackSnapshot,
+    cache: &mut HashMap<usize, probing_proto::prelude::CallFrame>,
+) {
+    if let Some(main_tid) = stack_capture::python_main_os_tid() {
+        if s.tid != main_tid {
             return;
         }
     }
-    let label = match loc.resolve_callee() {
-        Ok(sym) => {
-            let base = sym.file.rsplit(['/', '\\']).next().unwrap_or(&sym.file);
-            format!("[py] {} ({}:{})", sym.name, base, sym.line)
-        }
-        Err(_) => return,
-    };
-    if let Ok(mut g) = PY_SYMBOLS.write() {
-        if g.len() < PY_SYMBOLS_CAP {
-            g.entry(key).or_insert(label);
-        }
-    }
-}
-
-/// Drop all interned Python labels (called when the eval tracer is disabled).
-pub fn clear_py_symbols() {
-    if let Ok(mut g) = PY_SYMBOLS.write() {
-        g.clear();
-        g.shrink_to_fit();
-    }
-}
-
-/// Look up a sampled Python frame's label by callee pointer. Pure integer-keyed
-/// lookup — never touches Python memory, so it is safe on the consumer thread.
-fn resolve_py_frame(key: usize) -> String {
-    if key != 0 {
-        if let Ok(g) = PY_SYMBOLS.read() {
-            if let Some(label) = g.get(&key) {
-                return label.clone();
-            }
-        }
-    }
-    "[py] <unknown>".to_string()
-}
-
-/// A CPython interpreter eval frame (`_PyEval_EvalFrameDefault` / `EvalFrameEx`,
-/// with any C-ABI leading underscores). These are the splice points where a
-/// Python frame replaces the native frame. Matches `stack_tracer::merge_strategy`.
-#[inline]
-fn is_eval_frame(name: &str) -> bool {
-    let mut tokens = name.split(['_', '.']).filter(|s| !s.is_empty());
-    matches!(tokens.next(), Some("PyEval"))
-        && matches!(
-            tokens.next(),
-            Some("EvalFrameDefault") | Some("EvalFrameEx")
-        )
-}
-
-/// Our own eval-frame hook trampoline; dropped from mixed stacks as noise.
-#[inline]
-fn is_interp_shim(name: &str) -> bool {
-    name.contains("rust_eval_frame")
-}
-
-fn process_sample(s: &RawSample, cache: &mut HashMap<usize, String>) {
-    let nlen = s.native_len as usize;
-    let plen = s.py_len as usize;
-
-    // Native symbols, leaf -> root. Frame 0 is the interrupted PC (exact); every
-    // deeper frame is a *return address* pointing just past the call site, so we
-    // symbolize `addr - 1` to get the correct line / inlined-function.
-    let native_l2r: Vec<String> = (0..nlen)
-        .map(|i| {
-            let resolve_addr = if i == 0 {
-                s.native[i]
-            } else {
-                s.native[i].wrapping_sub(1)
-            };
-            symbolize_native(resolve_addr, cache)
-        })
-        .collect();
-    // Python frames, innermost -> outermost (PYSTACKS stores outermost -> innermost).
-    let py_l2r: Vec<String> = s.py[..plen]
-        .iter()
-        .rev()
-        .map(|&key| resolve_py_frame(key))
-        .collect();
-
-    let eval_count = native_l2r.iter().filter(|n| is_eval_frame(n)).count();
-
-    // Build leaf -> root, reversed to root -> leaf at the end.
-    let mut combined: Vec<String> = Vec::with_capacity(native_l2r.len() + py_l2r.len());
-
-    if eval_count > 0 && !py_l2r.is_empty() {
-        // True mixed mode: walking leaf -> root, replace each interpreter eval
-        // frame with the corresponding Python frame. Aligning from the leaf
-        // (deepest eval <-> innermost Python) keeps attribution correct even
-        // when a truncated fp-walk drops the outermost eval frames.
-        let mut pi = 0usize;
-        for n in &native_l2r {
-            if is_eval_frame(n) {
-                combined.push(py_l2r.get(pi).cloned().unwrap_or_else(|| n.clone()));
-                pi += 1;
-            } else if is_interp_shim(n) {
-                // drop our eval hook trampoline frame
-            } else {
-                combined.push(n.clone());
-            }
-        }
-        // Outer Python frames whose eval frames were lost to truncation: keep
-        // them toward the root so the logical context is not dropped.
-        if pi < py_l2r.len() {
-            combined.extend_from_slice(&py_l2r[pi..]);
-        }
-    } else if !native_l2r.is_empty() {
-        // No interpreter frames recovered (e.g. truncated walk or pure native):
-        // native tower with any Python frames hanging off the leaf.
-        combined.extend(py_l2r);
-        combined.extend(native_l2r.into_iter().filter(|n| !is_interp_shim(n)));
-    } else {
-        // Pure Python.
-        combined.extend(py_l2r);
-    }
-
-    if combined.is_empty() {
+    let line = stack_capture::snapshot_to_folded_line(s, cache);
+    if line.is_empty() {
         return;
     }
-    combined.reverse(); // root -> leaf
-
-    let mut line = match thread_name(s.tid) {
-        Some(name) => format!("thread-{} ({})", s.tid, name),
-        None => format!("thread-{}", s.tid),
-    };
-    for p in combined {
-        line.push(';');
-        line.push_str(&p);
-    }
-
     if let Ok(mut map) = SAMPLER.samples.lock() {
         if let Some(count) = map.get_mut(&line) {
             *count += 1;
         } else if map.len() < MAX_FOLDED_STACKS {
             map.insert(line, 1);
         } else {
-            // Cardinality cap hit: account the sample as dropped rather than
-            // grow the map without bound.
             DROPPED.fetch_add(1, Ordering::Relaxed);
         }
     }
 }
 
 fn consumer_loop(my_gen: u64) {
-    let mut sample = RawSample::zeroed();
-    let mut cache: HashMap<usize, String> = HashMap::new();
+    let mut sample = RawStackSnapshot::zeroed();
+    let mut cache = HashMap::new();
     loop {
         let stopping = SAMPLER.generation.load(Ordering::SeqCst) != my_gen;
         let ring = RING_PTR.load(Ordering::Acquire);
@@ -832,10 +254,6 @@ fn consumer_loop(my_gen: u64) {
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// Public API (stable for existing callers)
-// ---------------------------------------------------------------------------
 
 pub fn is_sampling_active() -> bool {
     SAMPLER_ENABLED.load(Ordering::Acquire)
@@ -861,7 +279,6 @@ fn setup_unix(freq: u64) -> Result<()> {
         (freq as i32).clamp(MIN_SAMPLE_FREQ, MAX_SAMPLE_FREQ)
     };
 
-    // Allocate the ring once.
     if RING_PTR.load(Ordering::Acquire).is_null() {
         let ptr = Box::into_raw(Box::new(Ring::new()));
         if RING_PTR
@@ -882,10 +299,6 @@ fn setup_unix(freq: u64) -> Result<()> {
     }
     DROPPED.store(0, Ordering::Relaxed);
 
-    // The sampler's Python frames come from the eval-frame hook; ensure it is on
-    // (idempotent) so we don't silently degrade to native-only stacks when the
-    // user enables pprof without separately enabling the tracer. Remember whether
-    // *we* turned it on, so `reset` only retires a tracer it owns.
     crate::features::vm_tracer::initialize_globals();
     pyo3::Python::attach(|_py| {
         let already_on = crate::features::vm_tracer::is_tracer_enabled();
@@ -905,6 +318,7 @@ fn setup_unix(freq: u64) -> Result<()> {
     install_handler();
 
     let my_gen = SAMPLER.generation.fetch_add(1, Ordering::SeqCst) + 1;
+    stack_capture::set_pprof_sampling_active(true);
     SAMPLER_ENABLED.store(true, Ordering::Release);
 
     thread::Builder::new()
@@ -919,12 +333,10 @@ fn setup_unix(freq: u64) -> Result<()> {
 
 pub fn reset() {
     disarm_timer();
+    stack_capture::set_pprof_sampling_active(false);
     SAMPLER_ENABLED.store(false, Ordering::Release);
     SAMPLER.generation.fetch_add(1, Ordering::SeqCst);
 
-    // Take the ring out of circulation, wait for any in-flight handler to drain,
-    // then free it. If we can't confirm quiescence (practically never, the
-    // handler is bounded), put it back rather than risk a use-after-free.
     let ring = RING_PTR.swap(std::ptr::null_mut(), Ordering::AcqRel);
     if !ring.is_null() {
         let mut drained = false;
@@ -942,17 +354,13 @@ pub fn reset() {
         }
     }
 
-    // Retire the eval tracer only if pprof was the one that enabled it.
     if PPROF_OWNS_TRACER.swap(false, Ordering::AcqRel) {
         pyo3::Python::attach(|_py| {
             let _ = crate::features::vm_tracer::disable_tracer();
         });
     }
 
-    clear_py_symbols();
-    if let Ok(mut m) = THREAD_NAMES.write() {
-        m.clear();
-    }
+    stack_capture::clear_py_symbols();
 }
 
 pub fn pprof_handler() {
@@ -963,16 +371,14 @@ fn pprof_flamegraph_options() -> FlamegraphOptions {
     FlamegraphOptions {
         title: "CPU sampling".to_string(),
         count_name: "samples".to_string(),
-        kind: FlamegraphKind::TorchModule,
+        kind: FlamegraphKind::Classic,
         subtitle: "SIGPROF weighted stack samples".to_string(),
         metric: None,
-        profile: None,
+        profile: Some("cpu-stack".to_string()),
     }
 }
 
-/// Snapshot the aggregate map into folded `"stack count"` lines under a single
-/// lock acquisition (no double-fold / TOCTOU between HTML and JSON paths).
-fn folded_lines() -> Vec<String> {
+fn folded_lines_from_sampler() -> Vec<String> {
     match SAMPLER.samples.lock() {
         Ok(map) => map
             .iter()
@@ -980,6 +386,236 @@ fn folded_lines() -> Vec<String> {
             .collect(),
         Err(_) => Vec::new(),
     }
+}
+
+/// Local folded stacks: SIGPROF main-thread samples when active, else a one-shot
+/// main-thread PYSTACKS snapshot (no signal on the HTTP path).
+fn local_folded_lines() -> Vec<String> {
+    if is_sampling_active() {
+        let lines = folded_lines_from_sampler();
+        if !lines.is_empty() {
+            return lines;
+        }
+    }
+    crate::features::stack_tracer::main_thread_on_demand_folded_lines()
+}
+
+fn folded_lines() -> Vec<String> {
+    local_folded_lines()
+}
+
+/// Snapshot of local SIGPROF folded stacks (`"path count"` per line).
+pub fn folded_lines_snapshot() -> Vec<String> {
+    folded_lines()
+}
+
+/// Build distributed stack flamegraph JSON from attributed folded lines across ranks.
+pub fn distributed_stack_flamegraph_json(
+    lines: &[crate::features::flamegraph::AttributedFoldedLine],
+    rank_count: usize,
+    nodes_failed: &[String],
+    mode: &str,
+) -> String {
+    let python_only = mode == "py";
+    let profile = if python_only {
+        "cpu-stack-distributed-py"
+    } else {
+        "cpu-stack-distributed"
+    };
+    let dropped = DROPPED.load(Ordering::Relaxed);
+    let empty = |msg: &str| {
+        json!({
+            "profile": profile,
+            "title": if python_only { "Distributed Python stacks" } else { "Distributed CPU stacks" },
+            "subtitle": format!(
+                "SIGPROF mixed-mode stacks · {rank_count} ranks · merge identical paths"
+            ),
+            "countName": "samples",
+            "total": 0,
+            "width": 1400.0,
+            "frameHeight": 32.0,
+            "frames": [],
+            "dropped": dropped,
+            "emptyMessage": msg,
+            "nodesFailed": nodes_failed,
+            "rankCount": rank_count,
+        })
+        .to_string()
+    };
+
+    if lines.is_empty() {
+        return empty(if python_only {
+            "no Python stack samples yet; enable SIGPROF (probing.pprof.sample_freq) on each rank and let training run"
+        } else {
+            "no main-thread CPU stack samples yet; enable SIGPROF (probing.pprof.sample_freq) on each rank"
+        });
+    }
+
+    let subtitle = if python_only {
+        if is_sampling_active() {
+            format!("Python frames only · SIGPROF main-thread samples · {rank_count} ranks merged")
+        } else {
+            format!("Python frames only · one-shot PYSTACKS snapshot · {rank_count} ranks merged")
+        }
+    } else if is_sampling_active() {
+        format!("Full mixed stack · SIGPROF main-thread samples · {rank_count} ranks merged")
+    } else {
+        format!(
+            "Full mixed stack · one-shot main-thread snapshot (enable SIGPROF for accumulation) · {rank_count} ranks merged"
+        )
+    };
+    let opts = FlamegraphOptions {
+        title: if python_only {
+            "Distributed Python stacks".to_string()
+        } else {
+            "Distributed CPU stacks".to_string()
+        },
+        count_name: "samples".to_string(),
+        kind: FlamegraphKind::Classic,
+        subtitle,
+        metric: None,
+        profile: Some(profile.to_string()),
+    };
+
+    match crate::features::flamegraph::Flamegraph::from_attributed_folded_lines(lines) {
+        Some(fg) => {
+            let payload = fg.json_payload(&opts);
+            match serde_json::from_str::<serde_json::Value>(&payload) {
+                Ok(mut v) => {
+                    if let Some(obj) = v.as_object_mut() {
+                        obj.insert("dropped".to_string(), json!(dropped));
+                        obj.insert("rankCount".to_string(), json!(rank_count));
+                        if !nodes_failed.is_empty() {
+                            obj.insert("nodesFailed".to_string(), json!(nodes_failed));
+                        }
+                    }
+                    v.to_string()
+                }
+                Err(_) => payload,
+            }
+        }
+        None => empty("no valid folded stacks after merge"),
+    }
+}
+
+fn local_training_rank() -> Option<i32> {
+    std::env::var("RANK")
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .or_else(|| {
+            std::env::var("LOCAL_RANK")
+                .ok()
+                .and_then(|s| s.trim().parse().ok())
+        })
+}
+
+fn remote_pprof_folded_lines_blocking(addr: &str) -> anyhow::Result<Vec<String>> {
+    let url = format!("http://{addr}/apis/pprofextension/flamegraph/folded/json");
+    let timeout = std::time::Duration::from_secs(
+        std::env::var("PROBING_CLUSTER_QUERY_TIMEOUT_SEC")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(10),
+    );
+    let text = ureq::get(&url)
+        .config()
+        .timeout_global(Some(timeout))
+        .build()
+        .call()?
+        .body_mut()
+        .read_to_string()?;
+    #[derive(serde::Deserialize)]
+    struct Payload {
+        lines: Vec<String>,
+    }
+    Ok(serde_json::from_str::<Payload>(&text)?.lines)
+}
+
+fn remote_pprof_flamegraph_json_blocking(addr: &str) -> anyhow::Result<String> {
+    let url = format!("http://{addr}/apis/pprofextension/flamegraph/json");
+    let timeout = std::time::Duration::from_secs(
+        std::env::var("PROBING_CLUSTER_QUERY_TIMEOUT_SEC")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(10),
+    );
+    let text = ureq::get(&url)
+        .config()
+        .timeout_global(Some(timeout))
+        .build()
+        .call()?
+        .body_mut()
+        .read_to_string()?;
+    Ok(text)
+}
+
+fn remote_pprof_folded_lines_fallback(addr: &str) -> anyhow::Result<Vec<String>> {
+    remote_pprof_folded_lines_blocking(addr).or_else(|_| {
+        let json = remote_pprof_flamegraph_json_blocking(addr)?;
+        Ok(crate::features::flamegraph::folded_lines_from_flamegraph_json(&json))
+    })
+}
+
+/// Cluster fan-out + merge for distributed CPU stack flamegraph JSON.
+///
+/// `mode`: `mixed` (Python + native) or `py` (Python frames only).
+///
+/// Returns `(json_body, partial)` where `partial` is true when some peers failed.
+pub async fn collect_distributed_stack_flamegraph_json(
+    cluster: bool,
+    mode: &str,
+) -> (String, bool) {
+    let mode = if mode == "py" { "py" } else { "mixed" };
+    use probing_core::core::cluster::{get_nodes, is_node_alive, local_listen_addrs};
+
+    let mut line_sets: Vec<(Option<i32>, Vec<String>)> =
+        vec![(local_training_rank(), folded_lines_snapshot())];
+    let mut nodes_failed = Vec::new();
+    let mut rank_count = 1usize;
+
+    if cluster {
+        let local_addrs = local_listen_addrs();
+        let peers: Vec<_> = get_nodes()
+            .into_iter()
+            .filter(is_node_alive)
+            .filter(|node| !local_addrs.iter().any(|local| local == &node.addr))
+            .collect();
+
+        for node in peers {
+            let addr = node.addr.clone();
+            let peer_rank = node.rank;
+            match tokio::task::spawn_blocking(move || remote_pprof_folded_lines_fallback(&addr))
+                .await
+            {
+                Ok(Ok(lines)) => {
+                    line_sets.push((peer_rank, lines));
+                    rank_count += 1;
+                }
+                Ok(Err(err)) => {
+                    log::warn!(
+                        "distributed stack flamegraph fan-out {} failed: {err:#}",
+                        node.addr
+                    );
+                    nodes_failed.push(format!("{}: {err:#}", node.addr));
+                }
+                Err(err) => {
+                    nodes_failed.push(format!("{}: task join failed: {err}", node.addr));
+                }
+            }
+        }
+    }
+
+    let mut merged = crate::features::flamegraph::merge_distributed_stack_attributed(&line_sets);
+    if mode == "py" {
+        merged = crate::features::flamegraph::filter_attributed_folded_lines_python_only(&merged);
+    }
+    let body = distributed_stack_flamegraph_json(&merged, rank_count, &nodes_failed, mode);
+    (body, !nodes_failed.is_empty())
+}
+
+/// Raw folded stack lines for cluster fan-out (`{"lines":["stack count", ...]}`).
+pub fn folded_lines_json() -> String {
+    json!({ "lines": folded_lines_snapshot() }).to_string()
 }
 
 pub fn flamegraph() -> Result<String> {
@@ -1000,7 +636,6 @@ pub fn flamegraph() -> Result<String> {
     Ok(fg.render_html(&pprof_flamegraph_options()))
 }
 
-/// JSON payload for the web UI (`GET /apis/pprofextension/flamegraph/json`).
 pub fn flamegraph_json() -> String {
     let dropped = DROPPED.load(Ordering::Relaxed);
     let empty = |msg: String| {
@@ -1021,13 +656,14 @@ pub fn flamegraph_json() -> String {
 
     let lines = folded_lines();
     if lines.is_empty() {
-        return empty("no samples collected yet; enable CPU sampling and let it run".to_string());
+        return empty(
+            "no samples collected yet; enable CPU sampling or use Stacks → Default".to_string(),
+        );
     }
 
     match crate::features::flamegraph::Flamegraph::from_folded_lines(&lines) {
         Some(fg) => {
             let payload = fg.json_payload(&pprof_flamegraph_options());
-            // Splice in the dropped-sample counter so the UI can warn on it.
             match serde_json::from_str::<serde_json::Value>(&payload) {
                 Ok(mut v) => {
                     if let Some(obj) = v.as_object_mut() {

--- a/probing/extensions/python/src/features/stack_capture.rs
+++ b/probing/extensions/python/src/features/stack_capture.rs
@@ -1,0 +1,814 @@
+//! Async-signal-safe stack snapshotting shared by SIGPROF and SIGUSR2.
+//!
+//! Signal handlers only copy raw PCs and eval-hook frame keys into a fixed POD
+//! struct. Symbolization and Python/native merge happen off the signal path via
+//! [`snapshot_to_merged_frames`].
+
+use std::cell::UnsafeCell;
+use std::collections::HashMap;
+use std::sync::atomic::{compiler_fence, AtomicBool, AtomicPtr, AtomicU64, AtomicUsize, Ordering};
+use std::sync::RwLock;
+use std::time::Duration;
+
+use core::ffi::{c_int, c_void};
+use nix::libc;
+use once_cell::sync::Lazy;
+use probing_proto::prelude::CallFrame;
+
+use crate::features::spy::call::RawCallLocation;
+use crate::features::spy::spy_tls_addrs;
+use crate::features::stack_merge::{demangle_native_symbol, merge_python_native_stacks};
+
+pub const MAX_NATIVE: usize = 48;
+pub const MAX_PY: usize = 128;
+const REG_SIZE: usize = 1024;
+
+/// Fixed-size POD snapshot copied from signal handlers.
+#[derive(Clone, Copy)]
+pub struct RawStackSnapshot {
+    pub tid: u64,
+    pub native_len: u32,
+    pub py_len: u32,
+    /// Native return addresses, leaf -> root.
+    pub native: [usize; MAX_NATIVE],
+    /// Callee `PyCodeObject` pointers, outermost -> innermost (`PYSTACKS` order).
+    pub py: [usize; MAX_PY],
+}
+
+impl RawStackSnapshot {
+    pub fn zeroed() -> Self {
+        RawStackSnapshot {
+            tid: 0,
+            native_len: 0,
+            py_len: 0,
+            native: [0usize; MAX_NATIVE],
+            py: [0usize; MAX_PY],
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.native_len == 0 && self.py_len == 0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Python-thread registry (TLS pointers resolved in normal context)
+// ---------------------------------------------------------------------------
+
+struct ThreadSlot {
+    tid: AtomicU64,
+    pystacks: AtomicPtr<Vec<RawCallLocation>>,
+    writing: AtomicPtr<bool>,
+    stack_lo: AtomicUsize,
+    stack_hi: AtomicUsize,
+    latest: UnsafeCell<RawStackSnapshot>,
+    latest_seq: AtomicU64,
+}
+
+// `latest` is published via `latest_seq` (Release/Acquire); only read after seq != 0.
+unsafe impl Sync for ThreadSlot {}
+
+static REG_TABLE: [ThreadSlot; REG_SIZE] = [const {
+    ThreadSlot {
+        tid: AtomicU64::new(0),
+        pystacks: AtomicPtr::new(std::ptr::null_mut()),
+        writing: AtomicPtr::new(std::ptr::null_mut()),
+        stack_lo: AtomicUsize::new(0),
+        stack_hi: AtomicUsize::new(0),
+        latest: UnsafeCell::new(RawStackSnapshot {
+            tid: 0,
+            native_len: 0,
+            py_len: 0,
+            native: [0usize; MAX_NATIVE],
+            py: [0usize; MAX_PY],
+        }),
+        latest_seq: AtomicU64::new(0),
+    }
+}; REG_SIZE];
+
+static REG_FULL_WARNED: AtomicBool = AtomicBool::new(false);
+static MAIN_OS_TID: AtomicU64 = AtomicU64::new(0);
+static PPROF_SAMPLING_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Record the Python main thread's OS tid (pthread id on macOS, gettid on Linux).
+pub fn register_main_os_tid() {
+    let tid = current_tid();
+    if tid == 0 {
+        return;
+    }
+    let _ = MAIN_OS_TID.compare_exchange(0, tid, Ordering::AcqRel, Ordering::Acquire);
+}
+
+pub fn python_main_os_tid() -> Option<u64> {
+    let tid = MAIN_OS_TID.load(Ordering::Acquire);
+    if tid == 0 {
+        None
+    } else {
+        Some(tid)
+    }
+}
+
+pub fn set_pprof_sampling_active(active: bool) {
+    PPROF_SAMPLING_ACTIVE.store(active, Ordering::Release);
+}
+
+pub fn is_pprof_sampling_active() -> bool {
+    PPROF_SAMPLING_ACTIVE.load(Ordering::Acquire)
+}
+
+thread_local! {
+    static THREAD_REGISTERED: std::cell::UnsafeCell<bool> = const { std::cell::UnsafeCell::new(false) };
+}
+
+static THREAD_NAMES: Lazy<RwLock<HashMap<u64, String>>> = Lazy::new(|| RwLock::new(HashMap::new()));
+
+/// Interned Python frame metadata keyed by callee `PyCodeObject` pointer.
+#[derive(Clone, Debug)]
+struct PyFrameSymbol {
+    func: String,
+    file: String,
+    lineno: i32,
+}
+
+impl PyFrameSymbol {
+    /// Folded flamegraph segment (basename only for cross-rank merge).
+    fn folded_label(&self) -> String {
+        let base = self.file.rsplit(['/', '\\']).next().unwrap_or(&self.file);
+        format!("[py] {} ({}:{})", self.func, base, self.lineno)
+    }
+
+    fn to_call_frame(&self) -> CallFrame {
+        CallFrame::PyFrame {
+            file: self.file.clone(),
+            func: self.func.clone(),
+            lineno: self.lineno as i64,
+            locals: Default::default(),
+        }
+    }
+}
+
+static PY_SYMBOLS: Lazy<RwLock<HashMap<usize, PyFrameSymbol>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
+const PY_SYMBOLS_CAP: usize = 1 << 18;
+
+#[inline]
+fn slot_hash(tid: u64) -> usize {
+    let h = tid.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    (h >> 40) as usize & (REG_SIZE - 1)
+}
+
+pub fn current_tid() -> u64 {
+    #[cfg(target_os = "linux")]
+    unsafe {
+        libc::syscall(libc::SYS_gettid) as u64
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let mut t: u64 = 0;
+        unsafe { libc::pthread_threadid_np(0, &mut t) };
+        t
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        0
+    }
+}
+
+fn current_thread_name() -> Option<String> {
+    let mut buf = [0 as libc::c_char; 64];
+    let rc = unsafe { libc::pthread_getname_np(libc::pthread_self(), buf.as_mut_ptr(), buf.len()) };
+    if rc != 0 {
+        return None;
+    }
+    let name = unsafe { std::ffi::CStr::from_ptr(buf.as_ptr()) }
+        .to_string_lossy()
+        .into_owned();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+fn current_stack_bounds() -> (usize, usize) {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        let pt = libc::pthread_self();
+        let base = libc::pthread_get_stackaddr_np(pt) as usize;
+        let size = libc::pthread_get_stacksize_np(pt);
+        (base.saturating_sub(size), base)
+    }
+    #[cfg(target_os = "linux")]
+    unsafe {
+        let mut attr: libc::pthread_attr_t = std::mem::zeroed();
+        if libc::pthread_getattr_np(libc::pthread_self(), &mut attr) != 0 {
+            return (0, 0);
+        }
+        let mut addr: *mut c_void = std::ptr::null_mut();
+        let mut size: libc::size_t = 0;
+        let ok = libc::pthread_attr_getstack(&attr, &mut addr, &mut size) == 0;
+        libc::pthread_attr_destroy(&mut attr);
+        if ok {
+            let lo = addr as usize;
+            (lo, lo + size)
+        } else {
+            (0, 0)
+        }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        (0, 0)
+    }
+}
+
+pub fn thread_name(tid: u64) -> Option<String> {
+    THREAD_NAMES.read().ok().and_then(|m| m.get(&tid).cloned())
+}
+
+pub fn register_python_thread() {
+    let already = THREAD_REGISTERED.with(|flag| unsafe {
+        if *flag.get() {
+            return true;
+        }
+        *flag.get() = true;
+        false
+    });
+    if already {
+        return;
+    }
+    let tid = current_tid();
+    if probing_core::is_python_main_thread() {
+        register_main_os_tid();
+    }
+    let (ps, wr) = spy_tls_addrs();
+    let (lo, hi) = current_stack_bounds();
+
+    if let Some(name) = current_thread_name() {
+        if let Ok(mut m) = THREAD_NAMES.write() {
+            m.insert(tid, name);
+        }
+    }
+
+    let publish = |slot: &ThreadSlot| {
+        slot.stack_lo.store(lo, Ordering::Release);
+        slot.stack_hi.store(hi, Ordering::Release);
+        slot.pystacks.store(ps, Ordering::Release);
+        slot.writing.store(wr, Ordering::Release);
+    };
+
+    let start = slot_hash(tid);
+    for i in 0..REG_SIZE {
+        let slot = &REG_TABLE[(start + i) & (REG_SIZE - 1)];
+        let v = slot.tid.load(Ordering::Acquire);
+        if v == tid {
+            publish(slot);
+            return;
+        }
+        if v == 0
+            && slot
+                .tid
+                .compare_exchange(0, tid, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+        {
+            publish(slot);
+            return;
+        }
+    }
+
+    if !REG_FULL_WARNED.swap(true, Ordering::Relaxed) {
+        log::warn!(
+            "probing: stack thread registry full ({REG_SIZE} threads); \
+             Python stacks for further threads will be missing"
+        );
+    }
+}
+
+fn thread_slot(tid: u64) -> Option<&'static ThreadSlot> {
+    let start = slot_hash(tid);
+    for i in 0..REG_SIZE {
+        let slot = &REG_TABLE[(start + i) & (REG_SIZE - 1)];
+        let v = slot.tid.load(Ordering::Acquire);
+        if v == tid {
+            return Some(slot);
+        }
+        if v == 0 {
+            return None;
+        }
+    }
+    None
+}
+
+/// Copy the registered thread's Python stack (PYSTACKS) without delivering a signal.
+pub fn copy_registered_py_snapshot(tid: u64) -> Option<RawStackSnapshot> {
+    let slot = thread_slot(tid)?;
+    let mut sample = RawStackSnapshot::zeroed();
+    sample.tid = tid;
+
+    let wr = slot.writing.load(Ordering::Acquire);
+    let ps = slot.pystacks.load(Ordering::Acquire);
+    if wr.is_null() || ps.is_null() || unsafe { *wr } {
+        return None;
+    }
+    compiler_fence(Ordering::SeqCst);
+    let stacks = unsafe { &*ps };
+    let n = stacks.len().min(MAX_PY);
+    for (i, stack) in stacks.iter().enumerate().take(n) {
+        sample.py[i] = stack.callee();
+    }
+    compiler_fence(Ordering::SeqCst);
+    if unsafe { *wr } {
+        return None;
+    }
+    sample.py_len = n as u32;
+    if sample.is_empty() {
+        None
+    } else {
+        Some(sample)
+    }
+}
+
+/// Store the latest SIGPROF snapshot for a thread so on-demand SIGUSR2 capture
+/// can reuse it without delivering another signal.
+pub fn store_latest_snapshot(snapshot: &RawStackSnapshot) {
+    if snapshot.is_empty() {
+        return;
+    }
+    let Some(slot) = thread_slot(snapshot.tid) else {
+        return;
+    };
+    unsafe {
+        *slot.latest.get() = *snapshot;
+    }
+    slot.latest_seq.fetch_add(1, Ordering::Release);
+}
+
+/// Reuse the latest SIGPROF snapshot for `tid` when CPU sampling is active.
+pub fn latest_snapshot_for_tid(tid: u64) -> Option<RawStackSnapshot> {
+    let slot = thread_slot(tid)?;
+    for _ in 0..4 {
+        let seq_before = slot.latest_seq.load(Ordering::Acquire);
+        if seq_before == 0 {
+            return None;
+        }
+        let snap = unsafe { *slot.latest.get() };
+        let seq_after = slot.latest_seq.load(Ordering::Acquire);
+        if seq_before == seq_after && snap.tid == tid && !snap.is_empty() {
+            return Some(snap);
+        }
+    }
+    None
+}
+
+pub fn intern_py_frame(loc: &RawCallLocation) {
+    let key = loc.callee();
+    if key == 0 {
+        return;
+    }
+    if let Ok(g) = PY_SYMBOLS.read() {
+        if g.contains_key(&key) {
+            return;
+        }
+    }
+    let entry = match loc.resolve_callee() {
+        Ok(sym) => PyFrameSymbol {
+            func: sym.name,
+            file: sym.file,
+            lineno: sym.line,
+        },
+        Err(_) => return,
+    };
+    if let Ok(mut g) = PY_SYMBOLS.write() {
+        if g.len() < PY_SYMBOLS_CAP {
+            g.entry(key).or_insert(entry);
+        }
+    }
+}
+
+pub fn clear_py_symbols() {
+    if let Ok(mut g) = PY_SYMBOLS.write() {
+        g.clear();
+        g.shrink_to_fit();
+    }
+}
+
+fn resolve_py_label(key: usize) -> String {
+    if key != 0 {
+        if let Ok(g) = PY_SYMBOLS.read() {
+            if let Some(sym) = g.get(&key) {
+                return sym.folded_label();
+            }
+        }
+    }
+    "[py] <unknown>".to_string()
+}
+
+fn resolve_py_call_frame(key: usize) -> CallFrame {
+    if key != 0 {
+        if let Ok(g) = PY_SYMBOLS.read() {
+            if let Some(sym) = g.get(&key) {
+                return sym.to_call_frame();
+            }
+        }
+    }
+    CallFrame::PyFrame {
+        file: String::new(),
+        func: resolve_py_label(key),
+        lineno: 0,
+        locals: Default::default(),
+    }
+}
+
+#[inline]
+fn plausible(p: usize) -> bool {
+    (0x1000..0x0001_0000_0000_0000).contains(&p)
+}
+
+#[allow(unused_variables)]
+unsafe fn regs_from_uctx(uctx: *mut c_void) -> (usize, usize) {
+    if uctx.is_null() {
+        return (0, 0);
+    }
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        let uc = uctx as *const libc::ucontext_t;
+        let mc = &(*uc).uc_mcontext;
+        let pc = mc.gregs[libc::REG_RIP as usize] as usize;
+        let fp = mc.gregs[libc::REG_RBP as usize] as usize;
+        (pc, fp)
+    }
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        let uc = uctx as *const libc::ucontext_t;
+        let mc = &(*uc).uc_mcontext;
+        (mc.pc as usize, mc.regs[29] as usize)
+    }
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    {
+        let uc = uctx as *const libc::ucontext_t;
+        let ss = &(*(*uc).uc_mcontext).__ss;
+        (ss.__rip as usize, ss.__rbp as usize)
+    }
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        let uc = uctx as *const libc::ucontext_t;
+        let ss = &(*(*uc).uc_mcontext).__ss;
+        (ss.__pc as usize, ss.__fp as usize)
+    }
+    #[cfg(not(any(
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "x86_64"),
+        all(target_os = "macos", target_arch = "aarch64"),
+    )))]
+    {
+        (0, 0)
+    }
+}
+
+unsafe fn walk_frame_pointers(start_fp: usize, out: &mut [usize], lo: usize, hi: usize) -> usize {
+    let bounded = hi != 0 && lo < hi;
+    let in_stack =
+        |fp: usize| !bounded || (fp >= lo && fp + 2 * std::mem::size_of::<usize>() <= hi);
+
+    let mut fp = start_fp;
+    let mut count = 0usize;
+    while count < out.len() {
+        if !plausible(fp) || (fp & 0x7) != 0 || !in_stack(fp) {
+            break;
+        }
+        let saved_fp = *(fp as *const usize);
+        let ret = *((fp + std::mem::size_of::<usize>()) as *const usize);
+        if !plausible(ret) {
+            break;
+        }
+        out[count] = ret;
+        count += 1;
+        if saved_fp <= fp || saved_fp - fp > 0x20_0000 {
+            break;
+        }
+        fp = saved_fp;
+    }
+    count
+}
+
+/// Async-signal-safe snapshot of the interrupted thread's native + Python stacks.
+///
+/// # Safety
+///
+/// `uctx` must be a valid `ucontext_t` pointer from a signal handler (or null,
+/// in which case native registers are skipped). Must only be called from an
+/// async-signal-safe context on the interrupted thread; the returned snapshot
+/// must not be shared with concurrent writers without synchronization.
+pub unsafe fn capture_raw_snapshot(uctx: *mut c_void) -> RawStackSnapshot {
+    let mut sample = RawStackSnapshot::zeroed();
+    sample.tid = current_tid();
+
+    let slot = thread_slot(sample.tid);
+    let (lo, hi) = match slot {
+        Some(s) => (
+            s.stack_lo.load(Ordering::Acquire),
+            s.stack_hi.load(Ordering::Acquire),
+        ),
+        None => (0, 0),
+    };
+
+    let (pc, fp) = regs_from_uctx(uctx);
+    let mut nlen = 0usize;
+    if plausible(pc) {
+        sample.native[nlen] = pc;
+        nlen += 1;
+    }
+    if nlen < MAX_NATIVE {
+        nlen += walk_frame_pointers(fp, &mut sample.native[nlen..], lo, hi);
+    }
+    sample.native_len = nlen as u32;
+
+    if let Some(slot) = slot {
+        let wr = slot.writing.load(Ordering::Acquire);
+        let ps = slot.pystacks.load(Ordering::Acquire);
+        if !wr.is_null() && !ps.is_null() && !*wr {
+            compiler_fence(Ordering::SeqCst);
+            let stacks = &*ps;
+            let n = stacks.len().min(MAX_PY);
+            for (i, stack) in stacks.iter().enumerate().take(n) {
+                sample.py[i] = stack.callee();
+            }
+            compiler_fence(Ordering::SeqCst);
+            sample.py_len = if *wr { 0 } else { n as u32 };
+        }
+    }
+
+    sample
+}
+
+pub fn symbolize_native_addr(addr: usize, cache: &mut HashMap<usize, CallFrame>) -> CallFrame {
+    if let Some(frame) = cache.get(&addr) {
+        return frame.clone();
+    }
+    let mut resolved_name: Option<String> = None;
+    let mut file_name = String::new();
+    let mut lineno = 0i64;
+    let mut lang: Option<String> = None;
+    backtrace::resolve(addr as *mut c_void, |sym| {
+        if resolved_name.is_none() {
+            if let Some(name) = sym.name().and_then(|n| n.as_str()) {
+                let (demangled, tag) = demangle_native_symbol(name);
+                resolved_name = Some(demangled);
+                lang = tag.map(str::to_string);
+            }
+            if let Some(path) = sym.filename() {
+                file_name = path.to_string_lossy().into_owned();
+            }
+            lineno = sym.lineno().unwrap_or(0) as i64;
+        }
+    });
+    let func = resolved_name.unwrap_or_else(|| format!("0x{addr:x}"));
+    let frame = CallFrame::CFrame {
+        ip: format!("{addr:#x}"),
+        file: file_name,
+        func,
+        lineno,
+        lang,
+    };
+    cache.insert(addr, frame.clone());
+    frame
+}
+
+/// Best-effort symbolize + merge off the signal path. Never propagates errors.
+pub fn snapshot_to_merged_frames(
+    snapshot: &RawStackSnapshot,
+    cache: &mut HashMap<usize, CallFrame>,
+) -> Vec<CallFrame> {
+    let nlen = snapshot.native_len as usize;
+    let plen = snapshot.py_len as usize;
+
+    let native_leaf_to_root: Vec<CallFrame> = (0..nlen)
+        .map(|i| {
+            let resolve_addr = if i == 0 {
+                snapshot.native[i]
+            } else {
+                snapshot.native[i].wrapping_sub(1)
+            };
+            symbolize_native_addr(resolve_addr, cache)
+        })
+        .collect();
+
+    let python_outer_to_inner: Vec<CallFrame> = snapshot.py[..plen]
+        .iter()
+        .map(|&key| resolve_py_call_frame(key))
+        .collect();
+
+    merge_python_native_stacks(&python_outer_to_inner, &native_leaf_to_root)
+}
+
+pub fn snapshot_to_folded_line(
+    snapshot: &RawStackSnapshot,
+    cache: &mut HashMap<usize, CallFrame>,
+) -> String {
+    let merged = snapshot_to_merged_frames(snapshot, cache);
+    if merged.is_empty() {
+        return String::new();
+    }
+    let segments = crate::features::stack_merge::merged_frames_to_folded_segments(&merged);
+    let mut line = match thread_name(snapshot.tid) {
+        Some(name) => format!("thread-{} ({})", snapshot.tid, name),
+        None => format!("thread-{}", snapshot.tid),
+    };
+    for seg in segments {
+        line.push(';');
+        line.push_str(&seg);
+    }
+    line
+}
+
+// ---------------------------------------------------------------------------
+// SIGUSR2 on-demand capture (same safe handler body as SIGPROF)
+// ---------------------------------------------------------------------------
+
+struct Sigusr2SnapshotSlot(UnsafeCell<RawStackSnapshot>);
+unsafe impl Sync for Sigusr2SnapshotSlot {}
+
+const ZERO_SNAPSHOT: RawStackSnapshot = RawStackSnapshot {
+    tid: 0,
+    native_len: 0,
+    py_len: 0,
+    native: [0usize; MAX_NATIVE],
+    py: [0usize; MAX_PY],
+};
+
+static SIGUSR2_HANDLER_INSTALLED: AtomicBool = AtomicBool::new(false);
+static SIGUSR2_ARMED: AtomicBool = AtomicBool::new(false);
+/// When armed, only this OS thread id may publish into [`SIGUSR2_SNAPSHOT`].
+static SIGUSR2_TARGET_TID: AtomicU64 = AtomicU64::new(0);
+static SIGUSR2_SEQ: AtomicU64 = AtomicU64::new(0);
+static SIGUSR2_SNAPSHOT: Sigusr2SnapshotSlot = Sigusr2SnapshotSlot(UnsafeCell::new(ZERO_SNAPSHOT));
+
+/// Generation counter before arming; [`take_sigusr2_snapshot`] returns data when seq advances.
+pub fn sigusr2_capture_generation() -> u64 {
+    SIGUSR2_SEQ.load(Ordering::Acquire)
+}
+
+pub fn set_sigusr2_armed(armed: bool) {
+    SIGUSR2_ARMED.store(armed, Ordering::Release);
+}
+
+pub fn take_sigusr2_snapshot(after_seq: u64) -> Option<RawStackSnapshot> {
+    if SIGUSR2_SEQ.load(Ordering::Acquire) <= after_seq {
+        return None;
+    }
+    let snap = unsafe { *SIGUSR2_SNAPSHOT.0.get() };
+    if snap.is_empty() {
+        None
+    } else {
+        Some(snap)
+    }
+}
+
+struct Sigusr2ArmGuard;
+
+impl Sigusr2ArmGuard {
+    fn new(target_tid: u64) -> Self {
+        SIGUSR2_TARGET_TID.store(target_tid, Ordering::Release);
+        SIGUSR2_ARMED.store(true, Ordering::Release);
+        Sigusr2ArmGuard
+    }
+}
+
+impl Drop for Sigusr2ArmGuard {
+    fn drop(&mut self) {
+        SIGUSR2_ARMED.store(false, Ordering::Release);
+        SIGUSR2_TARGET_TID.store(0, Ordering::Release);
+    }
+}
+
+/// Arm, deliver SIGUSR2 to `tid`, and wait for an async-signal-safe snapshot slot.
+#[cfg(unix)]
+pub fn capture_thread_snapshot_signal(tid: u64, timeout: Duration) -> Option<RawStackSnapshot> {
+    use std::time::Instant;
+
+    let _guard = Sigusr2ArmGuard::new(tid);
+    let seq_before = sigusr2_capture_generation();
+    let tid_i32 = tid as i32;
+
+    #[cfg(target_os = "linux")]
+    {
+        let pid = nix::unistd::getpid().as_raw();
+        let ret = unsafe { libc::syscall(libc::SYS_tgkill, pid, tid_i32, libc::SIGUSR2) };
+        if ret != 0 {
+            return None;
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if probing_core::signal::send_sigusr2_to_thread_id(tid_i32).is_err() {
+            return None;
+        }
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = (pid, tid_i32, timeout);
+        return None;
+    }
+
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Some(snap) = take_sigusr2_snapshot(seq_before) {
+            if snap.tid == tid {
+                return Some(snap);
+            }
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    None
+}
+
+#[cfg(not(unix))]
+pub fn capture_thread_snapshot_signal(_tid: u64, _timeout: Duration) -> Option<RawStackSnapshot> {
+    None
+}
+
+#[cfg(unix)]
+pub fn install_sigusr2_handler() {
+    if SIGUSR2_HANDLER_INSTALLED.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    unsafe {
+        let mut sa: libc::sigaction = std::mem::zeroed();
+        sa.sa_sigaction = sigusr2_stack_handler as *const () as usize;
+        sa.sa_flags = libc::SA_SIGINFO | libc::SA_RESTART;
+        libc::sigemptyset(&mut sa.sa_mask);
+        libc::sigaction(libc::SIGUSR2, &sa, std::ptr::null_mut());
+    }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn sigusr2_stack_handler(
+    _sig: c_int,
+    _info: *mut libc::siginfo_t,
+    uctx: *mut c_void,
+) {
+    if !SIGUSR2_ARMED.load(Ordering::Acquire) {
+        return;
+    }
+    let target = SIGUSR2_TARGET_TID.load(Ordering::Acquire);
+    if target == 0 {
+        return;
+    }
+    let snapshot = capture_raw_snapshot(uctx);
+    if snapshot.is_empty() || snapshot.tid != target {
+        return;
+    }
+    unsafe {
+        *SIGUSR2_SNAPSHOT.0.get() = snapshot;
+    }
+    SIGUSR2_SEQ.fetch_add(1, Ordering::Release);
+}
+
+#[cfg(not(unix))]
+pub fn install_sigusr2_handler() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_main_os_tid_is_idempotent() {
+        register_main_os_tid();
+        let first = python_main_os_tid();
+        register_main_os_tid();
+        assert_eq!(first, python_main_os_tid());
+        assert!(first.is_some());
+    }
+
+    #[test]
+    fn py_frame_symbol_folded_label_uses_basename() {
+        let sym = PyFrameSymbol {
+            func: "main".into(),
+            file: "examples/imagenet_with_span.py".into(),
+            lineno: 316,
+        };
+        assert_eq!(sym.folded_label(), "[py] main (imagenet_with_span.py:316)");
+    }
+
+    #[test]
+    fn py_frame_symbol_call_frame_keeps_full_path() {
+        let sym = PyFrameSymbol {
+            func: "main".into(),
+            file: "examples/imagenet_with_span.py".into(),
+            lineno: 316,
+        };
+        let frame = sym.to_call_frame();
+        match frame {
+            CallFrame::PyFrame {
+                file, func, lineno, ..
+            } => {
+                assert_eq!(file, "examples/imagenet_with_span.py");
+                assert_eq!(func, "main");
+                assert_eq!(lineno, 316);
+            }
+            other => panic!("expected PyFrame, got {other:?}"),
+        }
+    }
+}

--- a/probing/extensions/python/src/features/stack_merge.rs
+++ b/probing/extensions/python/src/features/stack_merge.rs
@@ -1,0 +1,324 @@
+//! Unified Python / native stack merge for SIGPROF, SIGUSR2, and synchronous walks.
+//!
+//! Python frames always come from the eval-frame hook (`vm_tracer` / `PYSTACKS`).
+//! Native frames are spliced at CPython eval-frame boundaries
+//! (`_PyEval_EvalFrameDefault` / `EvalFrameEx`).
+
+use std::collections::HashSet;
+
+use lazy_static::lazy_static;
+use probing_proto::prelude::CallFrame;
+
+lazy_static! {
+    static ref WHITELISTED_PREFIXES: HashSet<&'static str> = {
+        const PREFIXES: &[&str] = &[
+            "time",
+            "sys",
+            "gc",
+            "os",
+            "unicode",
+            "thread",
+            "stringio",
+            "sre",
+            "PyGilState",
+            "PyThread",
+            "lock",
+        ];
+        PREFIXES.iter().copied().collect()
+    };
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum MergeAction {
+    /// Drop interpreter trampoline noise.
+    Drop,
+    /// Keep the native frame as-is.
+    KeepNative,
+    /// Replace with the next Python frame from the eval hook.
+    SplicePython,
+}
+
+fn frame_symbol(frame: &CallFrame) -> &str {
+    match frame {
+        CallFrame::CFrame { func, .. } | CallFrame::PyFrame { func, .. } => func,
+    }
+}
+
+/// CPython eval splice point in a native stack tower.
+pub fn is_eval_frame_name(name: &str) -> bool {
+    let mut tokens = name.split(['_', '.']).filter(|s| !s.is_empty());
+    matches!(tokens.next(), Some("PyEval"))
+        && matches!(
+            tokens.next(),
+            Some("EvalFrameDefault") | Some("EvalFrameEx")
+        )
+}
+
+pub fn is_eval_frame(frame: &CallFrame) -> bool {
+    is_eval_frame_name(frame_symbol(frame))
+}
+
+/// Our eval-frame hook trampoline; dropped from mixed stacks as noise.
+pub fn is_interp_shim(frame: &CallFrame) -> bool {
+    frame_symbol(frame).contains("rust_eval_frame")
+}
+
+fn merge_action(frame: &CallFrame) -> MergeAction {
+    if is_interp_shim(frame) {
+        return MergeAction::Drop;
+    }
+    if is_interpreter_startup_native(frame_symbol(frame)) {
+        return MergeAction::Drop;
+    }
+    if is_eval_frame(frame) {
+        return MergeAction::SplicePython;
+    }
+    let symbol = frame_symbol(frame);
+    let mut tokens = symbol.split(['_', '.']).filter(|s| !s.is_empty());
+    match tokens.next() {
+        Some("PyEval") => MergeAction::Drop,
+        Some(prefix) if WHITELISTED_PREFIXES.contains(prefix) => MergeAction::KeepNative,
+        _ => MergeAction::KeepNative,
+    }
+}
+
+/// Demangle a native symbol name; returns `(display_name, lang_tag)`.
+pub fn demangle_native_symbol(raw_name: &str) -> (String, Option<&'static str>) {
+    if let Ok(d) = rustc_demangle::try_demangle(raw_name) {
+        return (d.to_string(), Some("rust"));
+    }
+    // macOS C ABI adds a leading `_` to Rust v0 mangling (`_R...` -> `__R...`).
+    if raw_name.starts_with("__R") {
+        if let Ok(d) = rustc_demangle::try_demangle(&raw_name[1..]) {
+            return (d.to_string(), Some("rust"));
+        }
+    }
+    if let Some(demangled) = cpp_demangle::Symbol::new(raw_name)
+        .ok()
+        .and_then(|sym| sym.demangle().ok())
+    {
+        return (demangled, Some("cpp"));
+    }
+    (raw_name.to_string(), None)
+}
+
+/// Merge Python eval-hook frames with a native stack captured leaf -> root.
+///
+/// `python_outer_to_inner` follows `PYSTACKS` / `get_python_stacks_raw` order
+/// (outermost Python frame first). `native_leaf_to_root` starts at the
+/// interrupted PC and walks toward the root.
+///
+/// Returns root -> leaf (caller -> callee), best-effort when walks truncate.
+pub fn merge_python_native_stacks(
+    python_outer_to_inner: &[CallFrame],
+    native_leaf_to_root: &[CallFrame],
+) -> Vec<CallFrame> {
+    if native_leaf_to_root.is_empty() {
+        return python_outer_to_inner.to_vec();
+    }
+    if python_outer_to_inner.is_empty() {
+        let mut out: Vec<CallFrame> = native_leaf_to_root
+            .iter()
+            .filter(|f| !is_interp_shim(f))
+            .filter(|f| !is_interpreter_startup_native(frame_symbol(f)))
+            .cloned()
+            .collect();
+        // Match the root -> leaf order returned by the merge paths below.
+        out.reverse();
+        return out;
+    }
+
+    // Innermost Python aligns with the deepest eval frame in the native walk.
+    let py_inner_to_outer: Vec<CallFrame> = python_outer_to_inner.iter().rev().cloned().collect();
+    let eval_count = native_leaf_to_root
+        .iter()
+        .filter(|f| is_eval_frame(f))
+        .count();
+
+    let mut merged_leaf_to_root: Vec<CallFrame> = Vec::new();
+
+    if eval_count > 0 {
+        let mut pi = 0usize;
+        for frame in native_leaf_to_root {
+            match merge_action(frame) {
+                MergeAction::Drop => {}
+                MergeAction::SplicePython => {
+                    if let Some(py) = py_inner_to_outer.get(pi) {
+                        merged_leaf_to_root.push(py.clone());
+                    } else {
+                        merged_leaf_to_root.push(frame.clone());
+                    }
+                    pi += 1;
+                }
+                MergeAction::KeepNative => merged_leaf_to_root.push(frame.clone()),
+            }
+        }
+        if pi < py_inner_to_outer.len() {
+            merged_leaf_to_root.extend_from_slice(&py_inner_to_outer[pi..]);
+        }
+    } else {
+        merged_leaf_to_root.extend(py_inner_to_outer);
+        merged_leaf_to_root.extend(
+            native_leaf_to_root
+                .iter()
+                .filter(|f| !is_interp_shim(f))
+                .filter(|f| !is_interpreter_startup_native(frame_symbol(f)))
+                .cloned(),
+        );
+    }
+
+    merged_leaf_to_root.reverse();
+    merged_leaf_to_root
+}
+
+/// Stdlib bootstrap frames that should not anchor a flamegraph root.
+fn is_stdlib_bootstrap_py_segment(seg: &str) -> bool {
+    if !seg.starts_with("[py]") {
+        return false;
+    }
+    seg.contains("builtins.py")
+        || seg.contains("<frozen")
+        || seg.contains("importlib/")
+        || seg.contains("runpy.py")
+        || seg.contains("zipimport.py")
+}
+
+/// CPython main / import bootstrap that sometimes appears above user `[py]` frames.
+fn is_interpreter_startup_native(name: &str) -> bool {
+    name.starts_with("_Py_RunMain")
+        || name.starts_with("pymain_")
+        || name.starts_with("_pymain_")
+        || name.starts_with("_PyRun_")
+        || name.starts_with("PyRun_")
+        || name.starts_with("_run_mod")
+        || name.starts_with("run_mod")
+        || name == "Py_BytesMain"
+        || name == "_Py_BytesMain"
+}
+
+/// Align folded paths for merge: drop leading native bootstrap and stdlib `[py]` noise.
+///
+/// SIGPROF samples occasionally include `_Py_RunMain` → … → user code while others
+/// start directly at `[py] <module> (script.py)`. Without this, identical stacks fork.
+pub fn canonicalize_folded_segments(segments: &[String]) -> Vec<String> {
+    if segments.is_empty() {
+        return Vec::new();
+    }
+    let py_start = segments
+        .iter()
+        .position(|s| s.starts_with("[py]"))
+        .unwrap_or(segments.len());
+    let mut out: Vec<String> = segments[py_start..].to_vec();
+    while out.len() > 1 && is_stdlib_bootstrap_py_segment(&out[0]) {
+        out.remove(0);
+    }
+    if out.is_empty() {
+        segments.to_vec()
+    } else {
+        out
+    }
+}
+
+/// Format merged frames as folded flamegraph segments (root -> leaf), canonicalized.
+pub fn merged_frames_to_folded_segments(frames: &[CallFrame]) -> Vec<String> {
+    let raw: Vec<String> = frames
+        .iter()
+        .map(|frame| match frame {
+            CallFrame::PyFrame {
+                file, func, lineno, ..
+            } => {
+                let base = file.rsplit(['/', '\\']).next().unwrap_or(file);
+                format!("[py] {func} ({base}:{lineno})")
+            }
+            CallFrame::CFrame { func, .. } => func.clone(),
+        })
+        .collect();
+    canonicalize_folded_segments(&raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn py(file: &str, func: &str, line: i64) -> CallFrame {
+        CallFrame::PyFrame {
+            file: file.into(),
+            func: func.into(),
+            lineno: line,
+            locals: Default::default(),
+        }
+    }
+
+    fn c(func: &str) -> CallFrame {
+        CallFrame::CFrame {
+            ip: "0x1".into(),
+            file: String::new(),
+            func: func.into(),
+            lineno: 0,
+            lang: Some("cpp".into()),
+        }
+    }
+
+    #[test]
+    fn canonicalize_drops_interpreter_bootstrap_before_user_py() {
+        let raw = vec![
+            "_Py_RunMain".to_string(),
+            "_pymain_run_file".to_string(),
+            "[py] <module> (imagenet_with_span.py:1)".to_string(),
+            "[py] main (imagenet_with_span.py:316)".to_string(),
+        ];
+        let out = canonicalize_folded_segments(&raw);
+        assert_eq!(
+            out,
+            vec![
+                "[py] <module> (imagenet_with_span.py:1)".to_string(),
+                "[py] main (imagenet_with_span.py:316)".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn canonicalize_is_idempotent_for_user_rooted_paths() {
+        let user = vec![
+            "[py] <module> (train.py:1)".to_string(),
+            "[py] train (train.py:10)".to_string(),
+        ];
+        assert_eq!(canonicalize_folded_segments(&user), user);
+    }
+
+    #[test]
+    fn eval_frames_splice_python_innermost_first() {
+        let native = vec![
+            c("leaf_native"),
+            c("_PyEval_EvalFrameDefault"),
+            c("caller_native"),
+        ];
+        // Outer -> inner; only one eval splice point, so leftover outer sits at root.
+        let python = vec![py("outer.py", "outer", 1), py("inner.py", "inner", 2)];
+        let merged = merge_python_native_stacks(&python, &native);
+        assert_eq!(
+            merged,
+            vec![
+                py("outer.py", "outer", 1),
+                c("caller_native"),
+                py("inner.py", "inner", 2),
+                c("leaf_native"),
+            ]
+        );
+    }
+
+    #[test]
+    fn drops_interp_shim() {
+        // Native input is leaf -> root; output must be root -> leaf.
+        let native = vec![c("leaf"), c("rust_eval_frame"), c("root")];
+        let merged = merge_python_native_stacks(&[], &native);
+        assert_eq!(merged, vec![c("root"), c("leaf")]);
+    }
+
+    #[test]
+    fn pure_python_passthrough() {
+        let python = vec![py("a.py", "a", 1), py("b.py", "b", 2)];
+        let merged = merge_python_native_stacks(&python, &[]);
+        assert_eq!(merged, python);
+    }
+}

--- a/probing/extensions/python/src/features/stack_tracer.rs
+++ b/probing/extensions/python/src/features/stack_tracer.rs
@@ -1,23 +1,20 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::sync::mpsc;
-use std::sync::Mutex;
 use std::time::Duration;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use lazy_static::lazy_static;
-use nix::libc;
 use once_cell::sync::Lazy;
 use pyo3::Python;
 
 use probing_proto::prelude::CallFrame;
 
 use probing_core::is_python_main_thread;
-#[cfg(target_os = "macos")]
-use probing_core::signal::send_sigusr2_to_thread_id;
 
-use crate::features::vm_tracer::{get_python_frames_raw, get_python_stacks_raw};
+use crate::features::stack_capture::{self, RawStackSnapshot};
+use crate::features::stack_merge::merged_frames_to_folded_segments;
+use crate::features::stack_merge::{demangle_native_symbol, merge_python_native_stacks};
+use crate::features::vm_tracer::get_python_stacks_raw;
 
 #[derive(Debug, thiserror::Error)]
 #[error("backtrace capture busy: {0}")]
@@ -25,67 +22,6 @@ pub(crate) struct BacktraceBusy(String);
 
 pub(crate) fn is_backtrace_busy(err: &anyhow::Error) -> bool {
     err.downcast_ref::<BacktraceBusy>().is_some()
-}
-
-fn demangle_native_symbol(raw_name: &str) -> (String, Option<&'static str>) {
-    if let Ok(d) = rustc_demangle::try_demangle(raw_name) {
-        return (d.to_string(), Some("rust"));
-    }
-    // macOS C ABI adds a leading `_` to Rust v0 mangling (`_R...` -> `__R...`).
-    if raw_name.starts_with("__R") {
-        if let Ok(d) = rustc_demangle::try_demangle(&raw_name[1..]) {
-            return (d.to_string(), Some("rust"));
-        }
-    }
-    if let Some(demangled) = cpp_demangle::Symbol::new(raw_name)
-        .ok()
-        .and_then(|sym| sym.demangle().ok())
-    {
-        return (demangled, Some("cpp"));
-    }
-    (raw_name.to_string(), None)
-}
-
-lazy_static! {
-    static ref WHITELISTED_PREFIXES: HashSet<&'static str> = {
-        const PREFIXES: &[&str] = &[
-            "time",
-            "sys",
-            "gc",
-            "os",
-            "unicode",
-            "thread",
-            "stringio",
-            "sre",
-            "PyGilState",
-            "PyThread",
-            "lock",
-        ];
-        PREFIXES.iter().copied().collect()
-    };
-}
-
-#[derive(Copy, Clone)]
-enum MergeType {
-    Ignore,
-    MergeNativeFrame,
-    MergePythonFrame,
-}
-
-fn merge_strategy(frame: &CallFrame) -> MergeType {
-    let symbol = match frame {
-        CallFrame::CFrame { func, .. } => func,
-        CallFrame::PyFrame { func, .. } => func,
-    };
-    let mut tokens = symbol.split(['_', '.']).filter(|s| !s.is_empty());
-    match tokens.next() {
-        Some("PyEval") => match tokens.next() {
-            Some("EvalFrameDefault" | "EvalFrameEx") => MergeType::MergePythonFrame,
-            _ => MergeType::Ignore,
-        },
-        Some(prefix) if WHITELISTED_PREFIXES.contains(prefix) => MergeType::MergeNativeFrame,
-        _ => MergeType::MergeNativeFrame,
-    }
 }
 
 #[async_trait]
@@ -97,8 +33,9 @@ pub trait StackTracer: Send + Sync + std::fmt::Debug {
 pub struct SignalTracer;
 
 impl SignalTracer {
-    fn get_native_stacks() -> Option<Vec<CallFrame>> {
-        let mut frames = vec![];
+    /// Walk the current thread without signals (safe under any Python runtime layout).
+    pub fn trace_current_thread_merged() -> Vec<CallFrame> {
+        let mut native_leaf_to_root = Vec::new();
         backtrace::trace(|frame| {
             let ip = frame.ip();
             backtrace::resolve_frame(frame, |symbol| {
@@ -112,7 +49,7 @@ impl SignalTracer {
                     .filename()
                     .map(|path| path.to_string_lossy().into_owned())
                     .unwrap_or_default();
-                frames.push(CallFrame::CFrame {
+                native_leaf_to_root.push(CallFrame::CFrame {
                     ip: format!("{ip:p}"),
                     file: file_name,
                     func: func_name,
@@ -122,163 +59,86 @@ impl SignalTracer {
             });
             true
         });
-        Some(frames)
-    }
 
-    fn send_frames(frames: Vec<CallFrame>) -> Result<()> {
-        match NATIVE_CALLSTACK_SENDER_SLOT.try_lock() {
-            Ok(guard) => {
-                if let Some(sender) = guard.as_ref() {
-                    sender.send(frames)?;
-                    Ok(())
-                } else {
-                    Err(anyhow::anyhow!("No sender available in channel slot"))
-                }
-            }
-            Err(_) => Err(anyhow::anyhow!("Failed to send frames via channel")),
-        }
-    }
-
-    fn merge_python_native_stacks(
-        python_stacks: Vec<CallFrame>,
-        native_stacks: Vec<CallFrame>,
-    ) -> Vec<CallFrame> {
-        let mut merged = vec![];
-        let mut python_frame_index = 0;
-
-        for frame in native_stacks {
-            match merge_strategy(&frame) {
-                MergeType::Ignore => {}
-                MergeType::MergeNativeFrame => merged.push(frame),
-                MergeType::MergePythonFrame => {
-                    if let Some(py_frame) = python_stacks.get(python_frame_index) {
-                        merged.push(py_frame.clone());
-                    }
-                    python_frame_index += 1;
-                }
-            }
-        }
-        merged
-    }
-
-    /// Walk the current thread without signals (safe under any Python runtime layout).
-    pub fn trace_current_thread_merged() -> Result<Vec<CallFrame>> {
-        let native = Self::get_native_stacks().unwrap_or_default();
-        let python = Python::attach(|_py| {
-            let from_tracer = get_python_stacks_raw();
-            if !from_tracer.is_empty() {
-                from_tracer
-            } else {
-                get_python_frames_raw(None)
-            }
-        });
+        let python = Python::attach(|_py| get_python_stacks_raw());
         if python.is_empty() {
-            return Ok(native);
+            native_leaf_to_root.reverse();
+            return native_leaf_to_root;
         }
-        if native.is_empty() {
-            return Ok(python);
+        if native_leaf_to_root.is_empty() {
+            return python;
         }
-        Ok(Self::merge_python_native_stacks(python, native))
+        merge_python_native_stacks(&python, &native_leaf_to_root)
     }
 
-    fn default_signal_tid() -> i32 {
-        nix::unistd::getpid().as_raw()
+    fn merged_from_snapshot(snapshot: &RawStackSnapshot) -> Vec<CallFrame> {
+        let mut cache = HashMap::new();
+        stack_capture::snapshot_to_merged_frames(snapshot, &mut cache)
     }
 
-    fn clear_sender_slot() {
-        if let Ok(mut guard) = NATIVE_CALLSTACK_SENDER_SLOT.try_lock() {
-            guard.take();
+    /// Read the Python main thread stack without SIGUSR2 (safe from HTTP / SQL workers).
+    fn trace_main_thread_off_signal() -> Result<Vec<CallFrame>> {
+        let main_tid = stack_capture::python_main_os_tid()
+            .ok_or_else(|| anyhow::anyhow!("Python main thread is not registered yet"))?;
+
+        if let Some(snapshot) = stack_capture::latest_snapshot_for_tid(main_tid) {
+            return Ok(Self::merged_from_snapshot(&snapshot));
         }
+
+        if let Some(snapshot) = stack_capture::copy_registered_py_snapshot(main_tid) {
+            let frames = Self::merged_from_snapshot(&snapshot);
+            if !frames.is_empty() {
+                return Ok(frames);
+            }
+        }
+
+        Err(anyhow::anyhow!(
+            "main-thread stack unavailable; enable SIGPROF sampling or retry while training is active"
+        ))
+    }
+
+    fn is_main_tid(tid: i32) -> bool {
+        stack_capture::python_main_os_tid().is_some_and(|main| main == tid as u64)
     }
 
     fn trace_thread_signal(tid: i32) -> Result<Vec<CallFrame>> {
-        let pid = nix::unistd::getpid().as_raw();
+        if Self::is_main_tid(tid) {
+            return Self::trace_main_thread_off_signal();
+        }
 
-        // Only one signal-based capture can run at a time (shared SIGUSR2 +
-        // sender slot). Concurrent requests losing the race is a benign "busy"
-        // state — the outer `trace()` already downgrades it to an empty result —
-        // so log at debug to avoid flooding training output with errors.
+        if stack_capture::is_pprof_sampling_active() {
+            if let Some(snapshot) = stack_capture::latest_snapshot_for_tid(tid as u64) {
+                return Ok(Self::merged_from_snapshot(&snapshot));
+            }
+        }
+
         let _guard = BACKTRACE_MUTEX.try_lock().map_err(|e| {
             let busy = BacktraceBusy(e.to_string());
             log::debug!("{busy}; skipping concurrent request");
             anyhow::Error::new(busy)
         })?;
 
-        let (tx, rx) = mpsc::channel::<Vec<CallFrame>>();
-        NATIVE_CALLSTACK_SENDER_SLOT
-            .try_lock()
-            .map_err(|err| {
-                log::error!("Failed to lock CALLSTACK_SENDER_SLOT: {err}");
-                anyhow::anyhow!("Failed to lock call stack sender slot")
-            })?
-            .replace(tx);
+        let snapshot =
+            stack_capture::capture_thread_snapshot_signal(tid as u64, Duration::from_secs(2))
+                .ok_or_else(|| {
+                    anyhow::anyhow!("timed out waiting for stack snapshot on thread {tid}")
+                })?;
 
-        log::debug!("Sending SIGUSR2 signal to process {pid} (thread: {tid})");
-
-        #[cfg(target_os = "linux")]
-        {
-            let ret = unsafe { libc::syscall(libc::SYS_tgkill, pid, tid, libc::SIGUSR2) };
-            if ret != 0 {
-                let last_error = std::io::Error::last_os_error();
-                Self::clear_sender_slot();
-                return Err(anyhow::anyhow!(
-                    "Failed to send SIGUSR2 to process {pid} (thread: {tid}): {last_error}"
-                ));
-            }
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            let signal_result = if tid == pid {
-                let ret = unsafe { libc::kill(pid, libc::SIGUSR2) };
-                if ret != 0 {
-                    Err(std::io::Error::last_os_error())
-                } else {
-                    Ok(())
-                }
-            } else {
-                send_sigusr2_to_thread_id(tid)
-            };
-            if let Err(e) = signal_result {
-                Self::clear_sender_slot();
-                return Err(anyhow::anyhow!(
-                    "Failed to send SIGUSR2 to process {pid} (thread: {tid}): {e}"
-                ));
-            }
-        }
-
-        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-        {
-            let _ = (pid, tid);
-            Self::clear_sender_slot();
-            return Err(anyhow::anyhow!(
-                "Stack tracing is not supported on this platform"
-            ));
-        }
-
-        let native_frames = match rx.recv_timeout(Duration::from_secs(2)) {
-            Ok(frames) => frames,
-            Err(err) => {
-                Self::clear_sender_slot();
-                return Err(err.into());
-            }
-        };
-        let python_frames = match rx.recv_timeout(Duration::from_secs(2)) {
-            Ok(frames) => frames,
-            Err(err) => {
-                Self::clear_sender_slot();
-                return Err(anyhow::anyhow!(
-                    "Python stack trace timed out or failed after native capture: {err}"
-                ));
-            }
-        };
-        Self::clear_sender_slot();
-
-        Ok(Self::merge_python_native_stacks(
-            python_frames,
-            native_frames,
-        ))
+        Ok(Self::merged_from_snapshot(&snapshot))
     }
+}
+
+/// On-demand main-thread stack as a single folded line (`"stack 1"`).
+pub fn main_thread_on_demand_folded_lines() -> Vec<String> {
+    let frames = match SignalTracer::trace_main_thread_off_signal() {
+        Ok(frames) if !frames.is_empty() => frames,
+        _ => return Vec::new(),
+    };
+    let segments = merged_frames_to_folded_segments(&frames);
+    if segments.is_empty() {
+        return Vec::new();
+    }
+    vec![format!("{} 1", segments.join(";"))]
 }
 
 #[async_trait]
@@ -286,14 +146,20 @@ impl StackTracer for SignalTracer {
     fn trace(&self, tid: Option<i32>) -> Result<Vec<CallFrame>> {
         log::debug!("Collecting backtrace for TID: {tid:?}");
 
-        // The CPU sampler now uses an async-signal-safe SIGPROF handler that does
-        // no heavy work, so it no longer conflicts with SIGUSR2 stack capture.
+        let explicit = tid.filter(|&t| t > 0);
 
-        if tid.is_none() && is_python_main_thread() {
-            return Self::trace_current_thread_merged();
+        if explicit.is_none() {
+            if is_python_main_thread() {
+                return Ok(Self::trace_current_thread_merged());
+            }
+            return Self::trace_main_thread_off_signal();
         }
 
-        let target = tid.unwrap_or_else(Self::default_signal_tid);
+        let target = explicit.unwrap();
+        if Self::is_main_tid(target) {
+            return Self::trace_main_thread_off_signal();
+        }
+
         match catch_unwind(AssertUnwindSafe(|| Self::trace_thread_signal(target))) {
             Ok(Ok(frames)) => Ok(frames),
             Ok(Err(err)) => {
@@ -306,7 +172,6 @@ impl StackTracer for SignalTracer {
             }
             Err(_) => {
                 log::warn!("Cross-thread stack trace panicked for tid {target}");
-                Self::clear_sender_slot();
                 Err(anyhow::anyhow!(
                     "cross-thread stack trace panicked for tid {target}"
                 ))
@@ -315,30 +180,4 @@ impl StackTracer for SignalTracer {
     }
 }
 
-pub fn backtrace_signal_handler() {
-    // Ignore stray SIGUSR2 (e.g. macOS tooling or other libraries). Only run
-    // capture logic while `trace_thread_signal` holds a receiver in the slot.
-    let expecting = NATIVE_CALLSTACK_SENDER_SLOT
-        .try_lock()
-        .ok()
-        .is_some_and(|guard| guard.is_some());
-    if !expecting {
-        return;
-    }
-
-    // Runs on the signaled thread: native unwind + thread-local eval-frame tracer stack.
-    let native_stacks = SignalTracer::get_native_stacks().unwrap_or_default();
-    if SignalTracer::send_frames(native_stacks).is_err() {
-        log::error!("Signal handler: failed to send native stacks (receiver may have timed out)");
-    }
-    let python_stacks = get_python_stacks_raw();
-    if SignalTracer::send_frames(python_stacks).is_err() {
-        log::error!("Signal handler: failed to send Python stacks from eval tracer");
-    }
-}
-
-/// Define a static Mutex for the backtrace function
 static BACKTRACE_MUTEX: Lazy<tokio::sync::Mutex<()>> = Lazy::new(|| tokio::sync::Mutex::new(()));
-
-pub static NATIVE_CALLSTACK_SENDER_SLOT: Lazy<Mutex<Option<mpsc::Sender<Vec<CallFrame>>>>> =
-    Lazy::new(|| Mutex::new(None));

--- a/probing/extensions/python/src/features/vm_tracer.rs
+++ b/probing/extensions/python/src/features/vm_tracer.rs
@@ -51,14 +51,14 @@ unsafe extern "C" fn rust_eval_frame(
     with_spy_state(|state| {
         // Mark this thread as a Python thread once; lets the SIGPROF sampler know its
         // thread-local `PYSTACKS` is allocated and safe to read from a signal handler.
-        crate::features::pprof::register_python_thread();
+        crate::features::stack_capture::register_python_thread();
 
         // Resolve this frame's callee symbol *now*, while the code object is alive
         // under the GIL, and cache it by pointer. The SIGPROF consumer later looks
         // the label up by integer key instead of dereferencing a possibly-freed
         // `PyCodeObject` off the signal path.
         let loc = RawCallLocation::from(frame as usize, Some(ts as usize));
-        crate::features::pprof::intern_py_frame(&loc);
+        crate::features::stack_capture::intern_py_frame(&loc);
 
         // Bracket the `PYSTACKS` mutation so a SIGPROF sample taken mid-realloc is
         // discarded instead of reading a torn `Vec`.
@@ -127,7 +127,7 @@ pub fn disable_tracer() -> PyResult<()> {
             });
         }
     }
-    crate::features::pprof::clear_py_symbols();
+    crate::features::stack_capture::clear_py_symbols();
     Ok(())
 }
 

--- a/probing/extensions/python/src/setup.rs
+++ b/probing/extensions/python/src/setup.rs
@@ -1,17 +1,3 @@
-pub fn register_signal_handler<F>(sig: std::ffi::c_int, handler: F)
-where
-    F: Fn() + Sync + Send + 'static,
-{
-    unsafe {
-        match signal_hook_registry::register_unchecked(sig, move |_: &_| handler()) {
-            Ok(_) => {
-                log::debug!("Registered signal handler for signal {sig}");
-            }
-            Err(e) => log::error!("Failed to register signal handler: {e}"),
-        }
-    };
-}
-
 #[ctor]
 fn setup() {
     use crate::python::{set_enabled, should_enable_probing};
@@ -30,15 +16,12 @@ fn setup() {
 
     #[cfg(unix)]
     if cfg!(test) {
-        // Unit-test processes must not run the SIGUSR2 stack handler: it calls
-        // backtrace/Python from signal context and aborts on stray delivery.
+        // Unit-test processes must not run the SIGUSR2 stack handler: it captures
+        // stacks from signal context and aborts on stray delivery.
         unsafe {
             nix::libc::signal(nix::libc::SIGUSR2, nix::libc::SIG_IGN);
         }
     } else {
-        register_signal_handler(
-            nix::libc::SIGUSR2,
-            crate::features::stack_tracer::backtrace_signal_handler,
-        );
+        crate::features::stack_capture::install_sigusr2_handler();
     }
 }

--- a/probing/server/API.md
+++ b/probing/server/API.md
@@ -22,7 +22,8 @@ Registered in `server/api/mod.rs`:
 | GET | `/apis/files?path=…` | Read workspace file |
 | GET/PUT | `/apis/nodes` | Cluster node list / register |
 | GET | `/apis/training/step_matrix` | Cross-rank train.step samples (`cluster=false` default; set `cluster=true` for on-demand fan-out) |
-| GET | `/apis/training/distributed_flamegraph/json` | SPMD torch module flamegraph at one `local_step` (`?step=` optional, `?metric=duration\|delta_mb\|peak_mb`, `cluster=true` default) |
+| GET | `/apis/training/distributed_flamegraph/json` | SPMD torch module flamegraph at one `local_step` (legacy; prefer distributed stack flamegraph) |
+| GET | `/apis/training/distributed_stack_flamegraph/json` | Distributed CPU stack flamegraph (`?cluster=true` default, `?mode=mixed\|py`). Frames may include `ranks: [i32]` (contributing training ranks under that partition) and payload `rankCount`. |
 | POST | `/apis/cluster/query` | On-demand SQL fan-out (`{"expr":"…","cluster":true}`; read-only SQL only) |
 
 Flamegraphs are served by profiler extensions (extension fallback, not public routes):
@@ -33,6 +34,8 @@ Flamegraphs are served by profiler extensions (extension fallback, not public ro
 | GET | `/apis/torchextension/flamegraph/json` | JSON for native Web UI (`?metric=` optional) |
 | GET | `/apis/pprofextension/flamegraph` | CPU sampling flamegraph (interactive HTML) |
 | GET | `/apis/pprofextension/flamegraph/json` | JSON for native Web UI |
+| GET | `/apis/pprofextension/flamegraph/folded/json` | Raw folded stack lines for cluster merge |
+| GET | `/apis/pprofextension/flamegraph/distributed/json` | Distributed SIGPROF stack flamegraph (`?cluster=true` default) |
 
 ## Cluster query (on-demand fan-out)
 

--- a/probing/server/src/server/api/mod.rs
+++ b/probing/server/src/server/api/mod.rs
@@ -21,6 +21,7 @@ pub const PUBLIC_API_ROUTES: &[(&str, &str)] = &[
     ("PUT", "/nodes"),
     ("GET", "/training/step_matrix"),
     ("GET", "/training/distributed_flamegraph/json"),
+    ("GET", "/training/distributed_stack_flamegraph/json"),
     ("POST", "/cluster/query"),
 ];
 
@@ -39,6 +40,10 @@ fn public_routes() -> Router {
         .route(
             "/training/distributed_flamegraph/json",
             get(training::get_distributed_flamegraph_json),
+        )
+        .route(
+            "/training/distributed_stack_flamegraph/json",
+            get(training::get_distributed_stack_flamegraph_json),
         )
         .route("/cluster/query", post(cluster_query::post_cluster_query))
 }

--- a/probing/server/src/server/training.rs
+++ b/probing/server/src/server/training.rs
@@ -413,6 +413,36 @@ pub async fn get_distributed_flamegraph_json(
     (status, [(header::CONTENT_TYPE, "application/json")], body).into_response()
 }
 
+#[derive(Debug, Deserialize)]
+pub struct DistributedStackFlamegraphParams {
+    pub cluster: Option<bool>,
+    /// `mixed` (default) = Python + native; `py` = Python frames only.
+    pub mode: Option<String>,
+}
+
+/// Distributed CPU stack flamegraph: merge SIGPROF folded stacks across cluster ranks.
+pub async fn get_distributed_stack_flamegraph_json(
+    axum::extract::Query(params): axum::extract::Query<DistributedStackFlamegraphParams>,
+) -> impl IntoResponse {
+    use axum::http::header;
+
+    if let Some(msg) = crate::engine_lifecycle::engine_not_ready_message() {
+        return ApiError::service_unavailable(msg).into_response();
+    }
+
+    let cluster = params.cluster.unwrap_or(true);
+    let mode = params.mode.as_deref().unwrap_or("mixed");
+    let (body, partial) =
+        probing_python::features::pprof::collect_distributed_stack_flamegraph_json(cluster, mode)
+            .await;
+    let status = if partial {
+        StatusCode::SERVICE_UNAVAILABLE
+    } else {
+        StatusCode::OK
+    };
+    (status, [(header::CONTENT_TYPE, "application/json")], body).into_response()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/python/probing/__init__.py
+++ b/python/probing/__init__.py
@@ -13,11 +13,15 @@ Public Interfaces (full import):
 
 from __future__ import annotations
 
-from probing._entrypoint import is_lightweight_module, is_probing_cli
+from probing._entrypoint import (
+    is_elastic_supervisor,
+    is_lightweight_module,
+    is_probing_cli,
+)
 
 VERSION = "0.2.5"
 
-if is_lightweight_module():
+if is_lightweight_module() or is_elastic_supervisor():
     __all__ = ["VERSION"]
 elif is_probing_cli():
     # Must set PROBING_CLI_MODE before loading _core so #[ctor] skips engine startup.

--- a/python/probing/_entrypoint.py
+++ b/python/probing/_entrypoint.py
@@ -80,3 +80,28 @@ def is_lightweight_module() -> bool:
     except (ValueError, IndexError):
         return False
     return mod in _LIGHTWEIGHT_MODULES
+
+
+def is_elastic_supervisor() -> bool:
+    """True for torchrun / ``python -m torch.distributed.run`` launcher (not a worker rank)."""
+    if os.environ.get("LOCAL_RANK") is not None or os.environ.get("RANK") is not None:
+        return False
+    if os.environ.get("TORCHELASTIC_RUN_ID"):
+        return True
+    if current_script_name() == "torchrun":
+        return True
+    if sys.argv[:1] == ["-m"]:
+        if len(sys.argv) >= 2 and not sys.argv[1].startswith("-"):
+            return False
+        return True
+    try:
+        idx = sys.argv.index("-m")
+        mod = sys.argv[idx + 1]
+    except (ValueError, IndexError):
+        mod = None
+    if mod in ("torch.distributed.run", "torch.distributed.launch"):
+        return True
+    return any(
+        (arg or "").endswith("torchrun") or "torch/distributed/run" in (arg or "")
+        for arg in sys.argv
+    )

--- a/python/probing/site_hook.py
+++ b/python/probing/site_hook.py
@@ -11,6 +11,7 @@ import sys
 
 from probing._entrypoint import (
     current_script_name,
+    is_elastic_supervisor,
     is_lightweight_module,
     is_probing_cli,
     should_activate_probing,
@@ -27,14 +28,7 @@ def run_site_hook() -> None:
     _RAN = True
 
     try:
-        import re
-
-        script = current_script_name()
-        if (
-            re.search("torchrun", script) is not None
-            or is_probing_cli()
-            or is_lightweight_module()
-        ):
+        if is_elastic_supervisor() or is_probing_cli() or is_lightweight_module():
             return
         _init_probing()
     except Exception as exc:

--- a/python/probing_hook.py
+++ b/python/probing_hook.py
@@ -1,5 +1,40 @@
 """Wheel / develop entry executed from ``probing.pth`` or ``probing_hook.pth``."""
 
-from probing.site_hook import run_site_hook
+from __future__ import annotations
 
-run_site_hook()
+import os
+import sys
+
+
+def _is_elastic_supervisor() -> bool:
+    """Match Rust ``is_elastic_supervisor`` without importing ``probing``."""
+    if os.environ.get("LOCAL_RANK") is not None or os.environ.get("RANK") is not None:
+        return False
+    if os.environ.get("TORCHELASTIC_RUN_ID"):
+        return True
+    if os.path.basename(sys.argv[0]) == "torchrun":
+        return True
+    # During site init for ``python -m <mod>``, CPython may only expose ``['-m', ...]``
+    # before the module name is appended. Worker ranks re-exec with RANK/LOCAL_RANK set.
+    if sys.argv[:1] == ["-m"]:
+        if len(sys.argv) >= 2 and not sys.argv[1].startswith("-"):
+            return False
+        return True
+    try:
+        idx = sys.argv.index("-m")
+        mod = sys.argv[idx + 1]
+    except (ValueError, IndexError):
+        mod = None
+    if mod in ("torch.distributed.run", "torch.distributed.launch"):
+        return True
+    return any(
+        (arg or "").endswith("torchrun") or "torch/distributed/run" in (arg or "")
+        for arg in sys.argv
+    )
+
+
+_sup = _is_elastic_supervisor()
+if not _sup:
+    from probing.site_hook import run_site_hook
+
+    run_site_hook()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,7 @@ fn start_local() {
 #[pymodule(gil_used = true)]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     register_python_main_thread();
+    probing_python::features::stack_capture::register_main_os_tid();
 
     // Initialize logging (try_init to avoid conflicts if already initialized via #[ctor])
     let _ = env_logger::try_init_from_env(env_logger::Env::new().filter(ENV_PROBING_LOGLEVEL));

--- a/tests/regression/profiling/test_distributed_flamegraph.py
+++ b/tests/regression/profiling/test_distributed_flamegraph.py
@@ -134,17 +134,21 @@ class TestDistributedFlamegraphContract:
         paths = {(r["method"], r["path"]) for r in spec["server_public"]}
         assert ("GET", "/apis/training/distributed_flamegraph/json") in paths
 
-    def test_web_client_declares_distributed_path(self):
+    def test_web_client_declares_distributed_stack_path(self):
         from pathlib import Path
 
         spec_path = Path(__file__).resolve().parents[1] / "spec" / "api_spec.json"
         spec = json.loads(spec_path.read_text(encoding="utf-8"))
-        profiling_calls: list[str] = []
+        stack_calls: list[str] = []
         for entry in spec["client_contracts"]["web"]:
-            if entry["source"] != "web/src/api/profiling.rs":
+            if entry["source"] != "web/src/api/stack.rs":
                 continue
-            profiling_calls.extend(c["path"] for c in entry["calls"])
-        assert "/apis/training/distributed_flamegraph/json" in profiling_calls
+            stack_calls.extend(c["path"] for c in entry["calls"])
+        assert "/apis/training/distributed_stack_flamegraph/json" in stack_calls
+
+        # Legacy torch SPMD endpoint remains server-public; Web UI uses stack flamegraph.
+        paths = {(r["method"], r["path"]) for r in spec["server_public"]}
+        assert ("GET", "/apis/training/distributed_flamegraph/json") in paths
 
     @staticmethod
     def _normalize_profiling_view(view: str) -> str:

--- a/tests/regression/spec/api_spec.json
+++ b/tests/regression/spec/api_spec.json
@@ -18,6 +18,7 @@
     { "method": "PUT", "path": "/apis/nodes" },
     { "method": "GET", "path": "/apis/training/step_matrix" },
     { "method": "GET", "path": "/apis/training/distributed_flamegraph/json" },
+    { "method": "GET", "path": "/apis/training/distributed_stack_flamegraph/json" },
     { "method": "POST", "path": "/apis/cluster/query" }
   ],
   "top_level": [
@@ -211,6 +212,20 @@
       "response": { "content_type": "application/json", "cors": false }
     },
     {
+      "extension_name": "pprofextension",
+      "method": "GET",
+      "path": "/apis/pprofextension/flamegraph/folded/json",
+      "local_path": "flamegraph/folded/json",
+      "response": { "content_type": "application/json", "cors": false }
+    },
+    {
+      "extension_name": "pprofextension",
+      "method": "GET",
+      "path": "/apis/pprofextension/flamegraph/distributed/json",
+      "local_path": "flamegraph/distributed/json",
+      "response": { "content_type": "application/json", "cors": false }
+    },
+    {
       "extension_name": "rdmaextension",
       "method": "POST",
       "path": "/apis/rdmaextension/",
@@ -261,13 +276,15 @@
         "source": "web/src/api/profiling.rs",
         "calls": [
           { "method": "GET", "path": "/apis/torchextension/flamegraph/json" },
-          { "method": "GET", "path": "/apis/pprofextension/flamegraph/json" },
-          { "method": "GET", "path": "/apis/training/distributed_flamegraph/json" }
+          { "method": "GET", "path": "/apis/pprofextension/flamegraph/json" }
         ]
       },
       {
         "source": "web/src/api/stack.rs",
-        "calls": [{ "method": "GET", "path": "/apis/pythonext/callstack" }]
+        "calls": [
+          { "method": "GET", "path": "/apis/pythonext/callstack" },
+          { "method": "GET", "path": "/apis/training/distributed_stack_flamegraph/json" }
+        ]
       },
       {
         "source": "web/src/api/trace.rs",

--- a/tests/unit/probing/test_entrypoint.py
+++ b/tests/unit/probing/test_entrypoint.py
@@ -1,0 +1,31 @@
+"""Unit tests for process entrypoint detection."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from probing import _entrypoint as ep
+
+
+@pytest.mark.parametrize(
+    ("argv", "env", "expected"),
+    [
+        (["python", "-m", "torch.distributed.run", "--standalone"], {}, True),
+        (["-m", "--help"], {}, True),
+        (["/usr/bin/torchrun", "train.py"], {}, True),
+        (["python", "examples/imagenet_with_span.py"], {"RANK": "0"}, False),
+        (["python", "examples/imagenet_with_span.py"], {"LOCAL_RANK": "1"}, False),
+        (["python", "-m", "torch.distributed.run"], {"TORCHELASTIC_RUN_ID": "x"}, True),
+        (["python", "examples/tracing.py"], {}, False),
+        (["-m", "probing.skills"], {}, False),
+    ],
+)
+def test_is_elastic_supervisor(argv, env, expected, monkeypatch):
+    monkeypatch.setattr(sys, "argv", argv)
+    for key in ("RANK", "LOCAL_RANK", "TORCHELASTIC_RUN_ID"):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    assert ep.is_elastic_supervisor() is expected

--- a/web/assets/tailwind.css
+++ b/web/assets/tailwind.css
@@ -1012,6 +1012,10 @@ video {
   margin-bottom: 0.125rem;
 }
 
+.-mb-px {
+  margin-bottom: -1px;
+}
+
 .-mt-0\.5 {
   margin-top: -0.125rem;
 }
@@ -1958,6 +1962,10 @@ video {
   border-bottom-width: 1px;
 }
 
+.border-b-2 {
+  border-bottom-width: 2px;
+}
+
 .border-l {
   border-left-width: 1px;
 }
@@ -2267,6 +2275,10 @@ video {
 
 .border-slate-700\/50 {
   border-color: rgb(51 65 85 / 0.5);
+}
+
+.border-slate-700\/80 {
+  border-color: rgb(51 65 85 / 0.8);
 }
 
 .border-slate-800 {

--- a/web/src/agent/routing.rs
+++ b/web/src/agent/routing.rs
@@ -33,6 +33,8 @@ pub fn page_id_for_route(route: &Route) -> String {
         Route::AgentPage {} => "agent".into(),
         Route::ClusterPage {} => "cluster".into(),
         Route::StackPage {} => "stacks".into(),
+        Route::StackDistributedFullPage {} => "stacks/distributed".into(),
+        Route::StackDistributedPyPage {} => "stacks/distributed/py".into(),
         Route::StackWithTidPage { tid } => format!("stacks/{tid}"),
         Route::ProfilingViewPage { view } => {
             format!("profiling/{}", normalize_profiling_view(view))

--- a/web/src/api/profiling.rs
+++ b/web/src/api/profiling.rs
@@ -57,28 +57,4 @@ impl ApiClient {
         };
         self.get_request(&path).await
     }
-
-    /// Distributed SPMD torch flamegraph at one ``local_step`` (cluster fan-out by default).
-    pub async fn get_distributed_flamegraph_json(
-        &self,
-        step: Option<i64>,
-        metric: Option<&str>,
-        cluster: bool,
-    ) -> Result<String> {
-        let mut parts = Vec::new();
-        if let Some(s) = step {
-            parts.push(format!("step={s}"));
-        }
-        if let Some(m) = metric {
-            if !m.is_empty() {
-                parts.push(format!("metric={}", urlencoding::encode(m)));
-            }
-        }
-        parts.push(format!("cluster={cluster}"));
-        let path = format!(
-            "/apis/training/distributed_flamegraph/json?{}",
-            parts.join("&")
-        );
-        self.get_request(&path).await
-    }
 }

--- a/web/src/api/stack.rs
+++ b/web/src/api/stack.rs
@@ -23,4 +23,20 @@ impl ApiClient {
         let response = self.get_request(&path).await?;
         Self::parse_json(&response)
     }
+
+    /// Distributed CPU stack flamegraph (`mode`: `mixed` | `py`).
+    pub async fn get_distributed_stack_flamegraph_json(
+        &self,
+        cluster: bool,
+        mode: &str,
+    ) -> Result<String> {
+        let mode = match mode {
+            "py" | "mixed" => mode,
+            _ => "mixed",
+        };
+        let path = format!(
+            "/apis/training/distributed_stack_flamegraph/json?cluster={cluster}&mode={mode}"
+        );
+        self.get_request(&path).await
+    }
 }

--- a/web/src/app.rs
+++ b/web/src/app.rs
@@ -11,8 +11,15 @@ use crate::components::app_overlays::AppOverlays;
 use crate::components::common::LoadingState;
 use crate::components::layout::AppLayout;
 use crate::pages::{
-    agent::Agent, analytics::Analytics, cluster::Cluster, dashboard::Dashboard,
-    profiling::Profiling, pulsing::Pulsing, python::Python, stack::Stack, traces::Traces,
+    agent::Agent,
+    analytics::Analytics,
+    cluster::Cluster,
+    dashboard::Dashboard,
+    profiling::Profiling,
+    pulsing::Pulsing,
+    python::Python,
+    stack::{Stack, StackDistributed},
+    traces::Traces,
     training::Training,
 };
 use crate::state::profiling::normalize_profiling_view;
@@ -29,6 +36,10 @@ pub enum Route {
     ClusterPage {},
     #[route("/stacks")]
     StackPage {},
+    #[route("/stacks/distributed")]
+    StackDistributedFullPage {},
+    #[route("/stacks/distributed/py")]
+    StackDistributedPyPage {},
     #[route("/stacks/:tid")]
     StackWithTidPage { tid: String },
     #[route("/profiling")]
@@ -79,6 +90,26 @@ pub fn StackWithTidPage(tid: String) -> Element {
 }
 
 #[component]
+pub fn StackDistributedFullPage() -> Element {
+    rsx! {
+        AppLayout {
+            fullscreen: true,
+            StackDistributed { mode: "mixed".to_string() }
+        }
+    }
+}
+
+#[component]
+pub fn StackDistributedPyPage() -> Element {
+    rsx! {
+        AppLayout {
+            fullscreen: true,
+            StackDistributed { mode: "py".to_string() }
+        }
+    }
+}
+
+#[component]
 pub fn ProfilingRedirect() -> Element {
     let nav = dioxus_router::use_navigator();
     use_effect(move || {
@@ -113,6 +144,11 @@ pub fn ChromeTracingRedirect() -> Element {
 #[component]
 pub fn ProfilingViewPage(view: String) -> Element {
     let canonical = normalize_profiling_view(&view).to_string();
+    if view == "torch-dist" || canonical == "torch-dist" {
+        return rsx! {
+            StackDistributedRedirect {}
+        };
+    }
     if view != canonical {
         return rsx! {
             ProfilingSlugRedirect { target: canonical }
@@ -123,6 +159,20 @@ pub fn ProfilingViewPage(view: String) -> Element {
         AppLayout {
             fullscreen: true,
             Profiling { key: "{canonical}", view: canonical }
+        }
+    }
+}
+
+#[component]
+fn StackDistributedRedirect() -> Element {
+    let nav = dioxus_router::use_navigator();
+    use_effect(move || {
+        nav.replace(Route::StackDistributedFullPage {});
+    });
+    rsx! {
+        AppLayout {
+            fullscreen: true,
+            LoadingState { message: Some("Opening distributed stacks…".to_string()) }
         }
     }
 }

--- a/web/src/components/flamegraph/explorer.rs
+++ b/web/src/components/flamegraph/explorer.rs
@@ -108,6 +108,10 @@ pub fn StackExplorerView(
         .map(|f| (f.name.clone(), f.id))
         .collect();
 
+    let selected_ranks = root.as_ref().map(|r| r.ranks.clone()).unwrap_or_default();
+    let is_distributed = profile.contains("distributed");
+    let rank_count = payload.rank_count;
+
     let reset_view = move |_| {
         zoom_id.set(root_id);
         phase_filter.set("all".to_string());
@@ -137,6 +141,13 @@ pub fn StackExplorerView(
                     }
                 }),
                 on_metric: on_torch_metric,
+            }
+            if is_distributed {
+                RankPartitionPanel {
+                    ranks: selected_ranks,
+                    rank_count,
+                    frame_name: root.as_ref().map(label_for_frame).unwrap_or_default(),
+                }
             }
             ExplorerBreadcrumbs {
                 ancestor_chain,
@@ -168,6 +179,54 @@ pub fn StackExplorerView(
             }
             if let Some(tip) = tooltip.read().clone() {
                 FloatingTooltip { state: tip }
+            }
+        }
+    }
+}
+
+#[component]
+fn RankPartitionPanel(ranks: Vec<i32>, rank_count: Option<usize>, frame_name: String) -> Element {
+    let ranks_label = if ranks.is_empty() {
+        "unknown".to_string()
+    } else {
+        ranks
+            .iter()
+            .map(|r| r.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    let coverage = match rank_count {
+        Some(n) if n > 0 && !ranks.is_empty() => {
+            format!(" · {}/{} ranks", ranks.len(), n)
+        }
+        _ if !ranks.is_empty() => format!(" · {} ranks", ranks.len()),
+        _ => String::new(),
+    };
+    let title = if frame_name.is_empty() || frame_name == "all" {
+        "Selected partition".to_string()
+    } else {
+        format!("Selected: {frame_name}")
+    };
+
+    rsx! {
+        div {
+            class: "px-4 py-2.5 border-b border-slate-200 bg-slate-50 flex flex-wrap items-start gap-2",
+            div { class: "min-w-0 flex-1",
+                p { class: "text-[10px] uppercase tracking-wide text-slate-500 mb-1", "{title}" }
+                p { class: "text-xs text-slate-600",
+                    span { class: "text-slate-500", "Ranks in this fork{coverage}: " }
+                    span { class: "font-mono text-slate-800 font-medium", "{ranks_label}" }
+                }
+            }
+            if !ranks.is_empty() {
+                div { class: "flex flex-wrap gap-1",
+                    for r in ranks.iter() {
+                        span {
+                            class: "inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-mono bg-white border border-slate-200 text-slate-700",
+                            "rank {r}"
+                        }
+                    }
+                }
             }
         }
     }
@@ -349,6 +408,15 @@ fn ExplorerFrameNode(
                         format_pct(frame_value, total),
                     ),
                 ];
+                if !frame.ranks.is_empty() {
+                    let ranks = frame
+                        .ranks
+                        .iter()
+                        .map(|r| r.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    lines.push(format!("Ranks: {ranks}"));
+                }
                 if let Some(path) = &frame.module_path {
                     lines.push(format!("{path_prefix}: {path}"));
                 }

--- a/web/src/components/flamegraph/model.rs
+++ b/web/src/components/flamegraph/model.rs
@@ -15,6 +15,9 @@ pub struct FlameFrame {
     pub phase: Option<String>,
     #[serde(rename = "modulePath", default)]
     pub module_path: Option<String>,
+    /// Training ranks that contributed samples under this frame (distributed only).
+    #[serde(default)]
+    pub ranks: Vec<i32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -38,4 +41,7 @@ pub struct FlamegraphPayload {
     /// as a warning; 0 / absent for profilers that don't report it.
     #[serde(default)]
     pub dropped: u64,
+    /// Number of ranks included in a distributed merge (when present).
+    #[serde(rename = "rankCount", default)]
+    pub rank_count: Option<usize>,
 }

--- a/web/src/components/sidebar/mod.rs
+++ b/web/src/components/sidebar/mod.rs
@@ -62,7 +62,10 @@ pub fn Sidebar() -> Element {
     use_effect(move || {
         if matches!(
             route_for_stack,
-            Route::StackPage {} | Route::StackWithTidPage { .. }
+            Route::StackPage {}
+                | Route::StackDistributedFullPage {}
+                | Route::StackDistributedPyPage {}
+                | Route::StackWithTidPage { .. }
         ) {
             *show_stack_dropdown.write() = true;
         }

--- a/web/src/components/sidebar/profiling/controls.rs
+++ b/web/src/components/sidebar/profiling/controls.rs
@@ -6,8 +6,7 @@ use crate::api::{ApiClient, ProfileResponse};
 use crate::components::colors::colors;
 use crate::hooks::use_api_simple;
 use crate::state::profiling::{
-    show_profiling_feedback, PROFILING_CHROME_LIMIT, PROFILING_DIST_CLUSTER, PROFILING_DIST_RELOAD,
-    PROFILING_DIST_STEP, PROFILING_PPROF_FREQ, PROFILING_PYTORCH_STEPS,
+    show_profiling_feedback, PROFILING_CHROME_LIMIT, PROFILING_PPROF_FREQ, PROFILING_PYTORCH_STEPS,
     PROFILING_PYTORCH_TIMELINE_RELOAD, PROFILING_RAY_TIMELINE_RELOAD, PROFILING_TORCH_ENABLED,
     PROFILING_TRACE_RELOAD,
 };
@@ -129,68 +128,6 @@ pub fn TorchControls(
                 span { class: "{toggle_label_class}",
                     if is_enabled { "Enabled" } else { "Disabled" }
                 }
-            }
-        }
-    }
-}
-
-#[component]
-pub fn TorchDistControls(
-    control_title_class: String,
-    control_value_class: String,
-    input_class: String,
-) -> Element {
-    let step = *PROFILING_DIST_STEP.read();
-    let cluster = *PROFILING_DIST_CLUSTER.read();
-    let step_label = step
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| "latest".to_string());
-
-    rsx! {
-        div {
-            class: "space-y-3",
-            div {
-                class: "space-y-1",
-                div { class: "{control_title_class}", "Training step" }
-                input {
-                    class: "{input_class} w-full",
-                    r#type: "number",
-                    min: "0",
-                    placeholder: "latest",
-                    value: step.map(|s| s.to_string()).unwrap_or_default(),
-                    oninput: move |ev| {
-                        let raw = ev.value().trim().to_string();
-                        if raw.is_empty() {
-                            *PROFILING_DIST_STEP.write() = None;
-                        } else if let Ok(s) = raw.parse::<i64>() {
-                            *PROFILING_DIST_STEP.write() = Some(s);
-                        }
-                    },
-                }
-                div { class: "{control_value_class} text-slate-400", "Step: {step_label}" }
-            }
-            label {
-                class: "flex items-center gap-2 cursor-pointer select-none text-xs text-slate-300",
-                input {
-                    r#type: "checkbox",
-                    checked: cluster,
-                    onchange: move |_| {
-                        *PROFILING_DIST_CLUSTER.write() = !*PROFILING_DIST_CLUSTER.read();
-                    },
-                }
-                "Cluster fan-out"
-            }
-            button {
-                class: format!(
-                    "w-full px-2 py-1.5 text-xs font-medium rounded bg-{} text-white hover:bg-{}",
-                    colors::PRIMARY,
-                    colors::PRIMARY_HOVER
-                ),
-                onclick: move |_| {
-                    *PROFILING_DIST_RELOAD.write() += 1;
-                    show_profiling_feedback("Reloading distributed flamegraph…", false);
-                },
-                "Reload flamegraph"
             }
         }
     }

--- a/web/src/components/sidebar/profiling/mod.rs
+++ b/web/src/components/sidebar/profiling/mod.rs
@@ -12,7 +12,7 @@ use crate::state::profiling::{normalize_profiling_view, profiling_view_label, PR
 
 mod controls;
 use controls::{
-    PprofControls, PyTorchTimelineControls, RayTimelineControls, TorchControls, TorchDistControls,
+    PprofControls, PyTorchTimelineControls, RayTimelineControls, TorchControls,
     TraceTimelineControls,
 };
 
@@ -20,7 +20,6 @@ fn profiling_view_icon(id: &str) -> &'static IconData {
     match id {
         "pprof" => &icondata::CgPerformance,
         "torch" => &icondata::AiFireOutlined,
-        "torch-dist" => &icondata::AiClusterOutlined,
         "trace" => &icondata::AiThunderboltOutlined,
         "pytorch" => &icondata::SiPytorch,
         "ray" => &icondata::AiClockCircleOutlined,
@@ -138,13 +137,6 @@ fn ProfilingControlsPanel(current_view: String) -> Element {
                             toggle_enabled_class: toggle_enabled_class,
                             toggle_disabled_class: toggle_disabled_class,
                             toggle_label_class: toggle_label_class,
-                        }
-                    },
-                    "torch-dist" => rsx! {
-                        TorchDistControls {
-                            control_title_class: control_title_class,
-                            control_value_class: control_value_class,
-                            input_class: input_class,
                         }
                     },
                     "trace" => rsx! {

--- a/web/src/components/sidebar/stack/mod.rs
+++ b/web/src/components/sidebar/stack/mod.rs
@@ -7,15 +7,27 @@ use crate::app::Route;
 use crate::components::colors::colors;
 use crate::components::icon::Icon;
 use crate::components::sidebar::nav_item::sidebar_item_class;
-use crate::state::stack::{bump_stack_refresh, stack_tid_label, STACK_MODE, STACK_SNAPSHOT};
+use crate::state::stack::{
+    bump_stack_refresh, stack_tid_label, STACK_DIST_CLUSTER, STACK_DIST_RELOAD, STACK_MODE,
+    STACK_SNAPSHOT,
+};
 use crate::utils::callframe::{mode_for_kind, FrameKind};
 
 #[component]
 pub fn StackSidebarItem(show_dropdown: Signal<bool>) -> Element {
     let route = use_route::<Route>();
-    let is_active = matches!(route, Route::StackPage {} | Route::StackWithTidPage { .. });
+    let is_active = matches!(
+        route,
+        Route::StackPage {}
+            | Route::StackDistributedFullPage {}
+            | Route::StackDistributedPyPage {}
+            | Route::StackWithTidPage { .. }
+    );
     let expanded = *show_dropdown.read();
     let on_default = matches!(route, Route::StackPage {});
+    let on_dist_full = matches!(route, Route::StackDistributedFullPage {});
+    let on_dist_py = matches!(route, Route::StackDistributedPyPage {});
+    let on_distributed = on_dist_full || on_dist_py;
     let tid = match &route {
         Route::StackWithTidPage { tid } => Some(tid.clone()),
         _ => None,
@@ -32,7 +44,7 @@ pub fn StackSidebarItem(show_dropdown: Signal<bool>) -> Element {
                 class: "{button_class}",
                 aria_expanded: if expanded { "true" } else { "false" },
                 aria_label: "Stacks menu",
-                title: "Live call stack — expand for filters",
+                title: "Live call stack and distributed CPU flamegraph",
                 onclick: move |_| {
                     let current = *show_dropdown.read();
                     *show_dropdown.write() = !current;
@@ -50,6 +62,18 @@ pub fn StackSidebarItem(show_dropdown: Signal<bool>) -> Element {
                         is_selected: on_default,
                         route: Route::StackPage {},
                     }
+                    StackSubLink {
+                        label: "Distributed · Full stack",
+                        hint: "Cluster flamegraph · Python + native merged across ranks",
+                        is_selected: on_dist_full,
+                        route: Route::StackDistributedFullPage {},
+                    }
+                    StackSubLink {
+                        label: "Distributed · Python",
+                        hint: "Cluster flamegraph · Python frames only across ranks",
+                        is_selected: on_dist_py,
+                        route: Route::StackDistributedPyPage {},
+                    }
                     if let Some(tid) = tid {
                         StackSubLink {
                             label: format!("tid {tid}"),
@@ -59,7 +83,11 @@ pub fn StackSidebarItem(show_dropdown: Signal<bool>) -> Element {
                         }
                     }
                     if is_active {
-                        StackControlsPanel {}
+                        if on_distributed {
+                            StackDistributedControlsPanel {}
+                        } else {
+                            StackControlsPanel {}
+                        }
                     }
                 }
             }
@@ -144,6 +172,54 @@ fn StackControlsPanel() -> Element {
                     onclick: move |_| bump_stack_refresh(),
                     "Refresh"
                 }
+            }
+        }
+    }
+}
+
+#[component]
+fn StackDistributedControlsPanel() -> Element {
+    let cluster = *STACK_DIST_CLUSTER.read();
+    let panel_border = colors::SIDEBAR_PANEL_BORDER;
+    let title_class = colors::SIDEBAR_CONTROL_TITLE;
+
+    rsx! {
+        div {
+            class: "{panel_border}",
+            div {
+                class: "px-1 space-y-3",
+                p {
+                    class: "text-[10px] uppercase tracking-wide text-slate-500",
+                    "Distributed flamegraph"
+                }
+                p {
+                    class: "text-[11px] text-slate-400 leading-snug",
+                    "Merge main-thread stacks from all ranks. Requires SIGPROF sampling (Profiling → CPU) for accumulated samples."
+                }
+                label {
+                    class: "flex items-center gap-2 cursor-pointer select-none text-xs text-slate-300",
+                    input {
+                        r#type: "checkbox",
+                        checked: cluster,
+                        onchange: move |_| {
+                            *STACK_DIST_CLUSTER.write() = !*STACK_DIST_CLUSTER.read();
+                        },
+                    }
+                    "Cluster fan-out"
+                }
+                button {
+                    r#type: "button",
+                    class: format!(
+                        "w-full px-2 py-1.5 text-xs font-medium rounded bg-{} text-white hover:bg-{}",
+                        colors::PRIMARY,
+                        colors::PRIMARY_HOVER
+                    ),
+                    onclick: move |_| {
+                        *STACK_DIST_RELOAD.write() += 1;
+                    },
+                    "Reload flamegraph"
+                }
+                p { class: "{title_class} text-[10px] text-slate-500", "Pprof frequency lives under Profiling → CPU (pprof)." }
             }
         }
     }

--- a/web/src/pages/profiling.rs
+++ b/web/src/pages/profiling.rs
@@ -17,9 +17,8 @@ use crate::state::investigation::{
 };
 use crate::state::profiling::{
     apply_profiler_config, normalize_profiling_view, profiling_view_spec, PROFILING_CHROME_LIMIT,
-    PROFILING_CONFIG_LOADED, PROFILING_DIST_CLUSTER, PROFILING_DIST_RELOAD, PROFILING_DIST_STEP,
-    PROFILING_PPROF_FREQ, PROFILING_PYTORCH_TIMELINE_RELOAD, PROFILING_RAY_TIMELINE_RELOAD,
-    PROFILING_TORCH_ENABLED, PROFILING_TRACE_RELOAD,
+    PROFILING_CONFIG_LOADED, PROFILING_PPROF_FREQ, PROFILING_PYTORCH_TIMELINE_RELOAD,
+    PROFILING_RAY_TIMELINE_RELOAD, PROFILING_TORCH_ENABLED, PROFILING_TRACE_RELOAD,
 };
 
 #[component]
@@ -54,7 +53,7 @@ pub fn Profiling(view: String) -> Element {
 fn view_icon(view: &str) -> &'static icondata::Icon {
     match view {
         "pprof" => &icondata::CgPerformance,
-        "torch" | "torch-dist" => &icondata::SiPytorch,
+        "torch" => &icondata::SiPytorch,
         "trace" => &icondata::AiThunderboltOutlined,
         "pytorch" => &icondata::SiPytorch,
         "ray" => &icondata::AiClockCircleOutlined,
@@ -66,9 +65,6 @@ fn view_subtitle(view: &str) -> String {
     match view {
         "pprof" => "SIGPROF stack explorer · statistical sampling".to_string(),
         "torch" => "Module flamegraph from TorchProbe hooks".to_string(),
-        "torch-dist" => {
-            "SPMD flamegraph — one training step, all ranks (merge identical stacks)".to_string()
-        }
         "trace" => "Chrome trace events from probing buffers — not distributed spans".to_string(),
         "pytorch" => "PyTorch profiler chrome trace".to_string(),
         "ray" => "Ray task timeline".to_string(),
@@ -97,12 +93,6 @@ fn ProfilerConfigGate(view: String) -> Element {
             AsyncBoundary {
                 message: Some("Loading flamegraph…".to_string()),
                 FlamegraphLoader { key: "{view}", view: view.clone() }
-            }
-        },
-        "torch-dist" => rsx! {
-            AsyncBoundary {
-                message: Some("Loading distributed flamegraph…".to_string()),
-                DistributedFlamegraphLoader { key: "{view}", view: view.clone() }
             }
         },
         "trace" => rsx! {
@@ -232,79 +222,6 @@ fn FlamegraphData(profiler_name: String) -> Element {
         Err(err) => rsx! {
             ProfilingErrorPanel {
                 title: "Flamegraph Error".to_string(),
-                error: err.display_message(),
-            }
-        },
-    }
-}
-
-#[component]
-fn DistributedFlamegraphLoader(view: String) -> Element {
-    let _ = view;
-    let torch_enabled = *PROFILING_TORCH_ENABLED.read();
-    if !torch_enabled {
-        return rsx! {
-            ProfilerDisabledNotice { profiler_name: "torch" }
-        };
-    }
-
-    let reload = *PROFILING_DIST_RELOAD.read();
-    let step = *PROFILING_DIST_STEP.read();
-    let cluster = *PROFILING_DIST_CLUSTER.read();
-
-    rsx! {
-        AsyncBoundary {
-            message: Some("Loading distributed flamegraph…".to_string()),
-            DistributedFlamegraphData {
-                key: "torch-dist-{reload}-{step:?}-{cluster}",
-                step,
-                cluster,
-            }
-        }
-    }
-}
-
-#[component]
-fn DistributedFlamegraphData(step: Option<i64>, cluster: bool) -> Element {
-    let mut metric = use_signal(|| "duration".to_string());
-    let fetch_step = step;
-    let fetch_cluster = cluster;
-
-    let payload = use_app_resource(move || {
-        let m = metric();
-        async move {
-            let client = ApiClient::new();
-            let body = client
-                .get_distributed_flamegraph_json(fetch_step, Some(&m), fetch_cluster)
-                .await?;
-            let parsed: FlamegraphPayload = serde_json::from_str(&body).map_err(|e| {
-                crate::utils::error::AppError::Api(format!("Invalid flamegraph JSON: {e}"))
-            })?;
-            Ok(parsed)
-        }
-    });
-
-    match payload.suspend()?() {
-        Ok(data) => rsx! {
-            div { class: "flex flex-col flex-1 min-h-0 min-w-0",
-                ProfileSnapshotBar {
-                    key: "torch-dist-{metric()}",
-                    profiler: "torch-dist".to_string(),
-                    metric: Some(metric()),
-                    payload: data.clone(),
-                }
-                FlamegraphView {
-                    key: "torch-dist-{metric()}",
-                    payload: data,
-                    thread_tid: None,
-                    torch_metric: Some(metric),
-                    on_torch_metric: Some(EventHandler::new(move |m: String| metric.set(m))),
-                }
-            }
-        },
-        Err(err) => rsx! {
-            ProfilingErrorPanel {
-                title: "Distributed Flamegraph Error".to_string(),
                 error: err.display_message(),
             }
         },

--- a/web/src/pages/stack.rs
+++ b/web/src/pages/stack.rs
@@ -1,13 +1,18 @@
 use dioxus::prelude::*;
+use dioxus_router::Link;
 use probing_proto::prelude::CallFrame;
 
 use crate::api::ApiClient;
+use crate::app::Route;
 use crate::components::callstack_view::CallStackView;
 use crate::components::common::{AsyncBoundary, EmptyState, ErrorState};
+use crate::components::flamegraph::{FlamegraphPayload, FlamegraphView};
 use crate::components::page::{PageContainer, PageTitle};
+use crate::components::profiling::{ProfilingContentPanel, ProfilingErrorPanel};
 use crate::hooks::use_app_resource;
 use crate::state::stack::{
-    stack_tid_label, StackSnapshot, STACK_MODE, STACK_REFRESH, STACK_SNAPSHOT,
+    stack_tid_label, StackSnapshot, STACK_DIST_CLUSTER, STACK_DIST_RELOAD, STACK_MODE,
+    STACK_REFRESH, STACK_SNAPSHOT,
 };
 use crate::utils::callframe::{count_by_kind, matches_mode};
 use crate::utils::error::AppError;
@@ -157,5 +162,102 @@ fn mode_label(mode: &str) -> &'static str {
         "rust" => "Rust",
         "cpp" => "Native",
         _ => "All",
+    }
+}
+
+/// Distributed stack flamegraph — merge identical stacks across ranks.
+#[component]
+pub fn StackDistributed(mode: String) -> Element {
+    let reload = *STACK_DIST_RELOAD.read();
+    let cluster = *STACK_DIST_CLUSTER.read();
+    let api_mode = if mode == "py" { "py" } else { "mixed" };
+    let on_full = api_mode == "mixed";
+    let subtitle = if api_mode == "py" {
+        "Distributed flamegraph · Python frames merged across ranks".to_string()
+    } else {
+        "Distributed flamegraph · full mixed stack merged across ranks".to_string()
+    };
+
+    rsx! {
+        PageContainer {
+            PageTitle {
+                title: "Distributed flamegraph".to_string(),
+                subtitle: Some(subtitle),
+                icon: Some(&icondata::AiClusterOutlined),
+            }
+            div { class: "flex flex-col flex-1 min-h-0 min-w-0 gap-3",
+                div {
+                    class: "flex gap-1 border-b border-slate-700/80",
+                    DistViewTab {
+                        label: "Full stack",
+                        active: on_full,
+                        route: Route::StackDistributedFullPage {},
+                    }
+                    DistViewTab {
+                        label: "Python only",
+                        active: !on_full,
+                        route: Route::StackDistributedPyPage {},
+                    }
+                }
+                ProfilingContentPanel {
+                    AsyncBoundary {
+                        message: Some("Loading distributed flamegraph…".to_string()),
+                        StackDistributedFlamegraph {
+                            key: "stack-dist-{reload}-{cluster}-{api_mode}",
+                            cluster,
+                            mode: api_mode.to_string(),
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn DistViewTab(label: &'static str, active: bool, route: Route) -> Element {
+    let class = if active {
+        "px-3 py-2 text-sm font-medium border-b-2 border-blue-500 text-blue-200 -mb-px"
+    } else {
+        "px-3 py-2 text-sm text-slate-400 hover:text-slate-200 border-b-2 border-transparent -mb-px"
+    };
+    rsx! {
+        Link {
+            to: route,
+            class: "{class}",
+            "{label}"
+        }
+    }
+}
+
+#[component]
+fn StackDistributedFlamegraph(cluster: bool, mode: String) -> Element {
+    let payload = use_app_resource(move || {
+        let mode = mode.clone();
+        async move {
+            let body = ApiClient::new()
+                .get_distributed_stack_flamegraph_json(cluster, &mode)
+                .await?;
+            let parsed: FlamegraphPayload = serde_json::from_str(&body)
+                .map_err(|e| AppError::Api(format!("Invalid flamegraph JSON: {e}")))?;
+            Ok(parsed)
+        }
+    });
+
+    match payload.suspend()?() {
+        Ok(data) => rsx! {
+            FlamegraphView {
+                payload: data,
+                thread_tid: None,
+                torch_metric: None,
+                on_torch_metric: None,
+            }
+        },
+        Err(err) => rsx! {
+            ProfilingErrorPanel {
+                title: "Distributed stack flamegraph".to_string(),
+                error: err.display_message(),
+            }
+        },
     }
 }

--- a/web/src/state/profiling.rs
+++ b/web/src/state/profiling.rs
@@ -12,7 +12,6 @@ pub fn normalize_profiling_view(view: &str) -> &'static str {
     match view {
         "" | "pprof" => "pprof",
         "torch" => "torch",
-        "torch-dist" | "distributed-torch" | "torch-distributed" => "torch-dist",
         "trace" | "trace-timeline" => "trace",
         "pytorch" | "pytorch-timeline" => "pytorch",
         "ray" | "ray-timeline" => "ray",
@@ -55,10 +54,6 @@ pub static PROFILING_PYTORCH_STEPS: GlobalSignal<i32> = Signal::global(|| 5);
 pub static PROFILING_PYTORCH_TIMELINE_RELOAD: GlobalSignal<i32> = Signal::global(|| 0);
 pub static PROFILING_RAY_TIMELINE_RELOAD: GlobalSignal<i32> = Signal::global(|| 0);
 pub static PROFILING_TRACE_RELOAD: GlobalSignal<i32> = Signal::global(|| 0);
-/// Optional ``local_step`` for distributed torch flamegraph (``None`` = latest on server).
-pub static PROFILING_DIST_STEP: GlobalSignal<Option<i64>> = Signal::global(|| None);
-pub static PROFILING_DIST_CLUSTER: GlobalSignal<bool> = Signal::global(|| true);
-pub static PROFILING_DIST_RELOAD: GlobalSignal<i32> = Signal::global(|| 0);
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ProfilingFeedback {
@@ -105,12 +100,6 @@ pub const PROFILING_VIEWS: &[ProfilingViewSpec] = &[
         label: "Torch modules",
         sidebar_label: "Torch flamegraph",
         tooltip: "PyTorch module hook durations · statistical flamegraph (not the profiler timeline)",
-    },
-    ProfilingViewSpec {
-        id: "torch-dist",
-        label: "Distributed torch",
-        sidebar_label: "Distributed flamegraph",
-        tooltip: "SPMD snapshot at one training step — merge identical module stacks across ranks",
     },
     ProfilingViewSpec {
         id: "trace",

--- a/web/src/state/stack.rs
+++ b/web/src/state/stack.rs
@@ -15,6 +15,8 @@ pub struct StackSnapshot {
 
 pub static STACK_MODE: GlobalSignal<String> = Signal::global(|| String::from("mixed"));
 pub static STACK_REFRESH: GlobalSignal<u32> = Signal::global(|| 0);
+pub static STACK_DIST_CLUSTER: GlobalSignal<bool> = Signal::global(|| true);
+pub static STACK_DIST_RELOAD: GlobalSignal<i32> = Signal::global(|| 0);
 pub static STACK_SNAPSHOT: GlobalSignal<StackSnapshot> = Signal::global(StackSnapshot::default);
 
 pub fn stack_tid_label(tid: Option<&str>) -> String {


### PR DESCRIPTION
- Added 'frontend/' to .gitignore for improved project cleanliness.
- Removed 'signal-hook-registry' from Cargo.lock and added 'ureq' to dependencies.
- Enhanced profiling documentation in both English and Chinese to clarify stack capture mechanisms and improve user guidance on using the TorchProfiler.
- Introduced new functions in `imagenet_with_span.py` for distributed training argument configuration and initialization, improving the setup for distributed demos.

These changes aim to streamline project management and enhance the usability of profiling features.