### PR TITLE
Fix hccl-shim deadlock and expand Msprof passthrough exports

### DIFF
--- a/probing/cli/src/inject/injection_aarch64.rs
+++ b/probing/cli/src/inject/injection_aarch64.rs
@@ -346,7 +346,7 @@ impl InjectionTrait for InjectionAarch64<'_> {
         // lifetime as the tracer reference, and the injection will be removed before
         // the tracer goes out of scope in perform_injection.
         unsafe {
-            let tracer_ref = &mut *(tracer as *mut pete::Ptracer);
+            let tracer_ref = &mut *std::ptr::from_mut::<pete::Ptracer>(tracer);
             Self::inject(proc, tracer_ref, tracee)
         }
     }
@@ -381,19 +381,19 @@ mod tests {
     #[test]
     fn register_handling() {
         let mut regs: Registers = unsafe { std::mem::zeroed() };
-        regs.regs[0] = 0x12345678;
-        regs.regs[1] = 0x87654321;
-        regs.regs[2] = 0x11111111;
-        regs.regs[3] = 0x22222222;
-        regs.regs[8] = 0xdeadbeef;
+        regs.regs[0] = 0x1234_5678;
+        regs.regs[1] = 0x8765_4321;
+        regs.regs[2] = 0x1111_1111;
+        regs.regs[3] = 0x2222_2222;
+        regs.regs[8] = 0xdead_beef;
         regs.sp = 0x1000;
         regs.pc = 0x2000;
 
-        assert_eq!(regs.regs[0], 0x12345678);
-        assert_eq!(regs.regs[1], 0x87654321);
-        assert_eq!(regs.regs[2], 0x11111111);
-        assert_eq!(regs.regs[3], 0x22222222);
-        assert_eq!(regs.regs[8], 0xdeadbeef);
+        assert_eq!(regs.regs[0], 0x1234_5678);
+        assert_eq!(regs.regs[1], 0x8765_4321);
+        assert_eq!(regs.regs[2], 0x1111_1111);
+        assert_eq!(regs.regs[3], 0x2222_2222);
+        assert_eq!(regs.regs[8], 0xdead_beef);
         assert_eq!(regs.sp & !0xf, 0x1000);
     }
 }

--- a/probing/extensions/hccl-shim/src/forward.rs
+++ b/probing/extensions/hccl-shim/src/forward.rs
@@ -8,8 +8,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use once_cell::sync::Lazy;
-use parking_lot::Mutex;
+use once_cell::sync::OnceCell;
 
 type ProfCommandHandle = Option<unsafe extern "C" fn(u32, *mut c_void, u32) -> i32>;
 
@@ -19,6 +18,21 @@ type FnReportApi = unsafe extern "C" fn(u32, *const c_void) -> i32;
 type FnReportBlob = unsafe extern "C" fn(u32, *const c_void, u32) -> i32;
 type FnGetHashId = unsafe extern "C" fn(*const c_char, u32) -> u64;
 type FnSysCycleTime = unsafe extern "C" fn() -> u64;
+type FnI32 = unsafe extern "C" fn() -> i32;
+type FnBool = unsafe extern "C" fn() -> bool;
+type FnInit = unsafe extern "C" fn(u32, *mut c_void, u32) -> i32;
+type FnStartStop = unsafe extern "C" fn(u32, *const c_void, u32) -> i32;
+type FnReportData = unsafe extern "C" fn(u32, u32, *mut c_void, u32) -> i32;
+type FnNotifySetDevice = unsafe extern "C" fn(u32, u32, bool) -> i32;
+type FnProfileCallback = unsafe extern "C" fn(i32, *mut c_void, u32) -> i32;
+type FnSetConfig = unsafe extern "C" fn(u32, *const c_char, usize) -> i32;
+type FnReportEvent = unsafe extern "C" fn(u32, *const c_void) -> i32;
+type FnBatchMax = unsafe extern "C" fn(u32) -> usize;
+type FnRegFormat = unsafe extern "C" fn(u16, u32, *const c_char) -> i32;
+type FnStr2Id = unsafe extern "C" fn(*const c_char, usize) -> u64;
+type FnGeModel = unsafe extern "C" fn(u32, u32) -> i32;
+type FnRawCb = Option<unsafe extern "C" fn(*mut c_void) -> i32>;
+type FnSubscribe = unsafe extern "C" fn(FnRawCb) -> i32;
 
 struct RealApi {
     register_callback: FnRegisterCallback,
@@ -28,27 +42,50 @@ struct RealApi {
     report_additional: FnReportBlob,
     get_hash_id: FnGetHashId,
     sys_cycle_time: FnSysCycleTime,
+    // Required when LD_LIBRARY_PATH points at this shim (Ascend runtime links libprofapi).
+    report_data: Option<FnReportData>,
+    init: Option<FnInit>,
+    finalize: Option<FnI32>,
+    start: Option<FnStartStop>,
+    stop: Option<FnStartStop>,
+    notify_set_device: Option<FnNotifySetDevice>,
+    register_profile_callback: Option<FnProfileCallback>,
+    set_config: Option<FnSetConfig>,
+    report_event: Option<FnReportEvent>,
+    report_batch_additional: Option<FnReportBlob>,
+    get_batch_max: Option<FnBatchMax>,
+    reg_data_format: Option<FnRegFormat>,
+    str2id: Option<FnStr2Id>,
+    set_device_by_ge: Option<FnGeModel>,
+    unset_device_by_ge: Option<FnGeModel>,
+    host_freq_is_enable: Option<FnBool>,
+    subscribe_raw: Option<FnSubscribe>,
+    unsubscribe_raw: Option<FnI32>,
+    // Atlas / ACL registration entry points (needed for acl.prof.init).
+    prof_reg_reporter: Option<unsafe extern "C" fn(Option<unsafe extern "C" fn(u32, u32, *mut c_void, u32) -> i32>) -> i32>,
+    prof_reg_ctrl: Option<unsafe extern "C" fn(Option<unsafe extern "C" fn(u32, *mut c_void, u32) -> i32>) -> i32>,
+    prof_reg_device_state: Option<unsafe extern "C" fn(Option<unsafe extern "C" fn(*mut c_void, u32) -> i32>) -> i32>,
+    prof_get_device_by_ge: Option<unsafe extern "C" fn(u32, *mut u32) -> i32>,
+    prof_set_command: Option<unsafe extern "C" fn(*mut c_void, u32) -> i32>,
+    prof_set_step_info: Option<unsafe extern "C" fn(u64, u16, *mut c_void) -> i32>,
 }
 
 struct RealLib {
+    // Kept for the process lifetime; never dlclosed, so it is intentionally unread.
+    #[allow(dead_code)]
     handle: *mut c_void,
     api: RealApi,
 }
 
 unsafe impl Send for RealLib {}
+// SAFETY: after one-time init the handle/function pointers are only ever read.
+// The real library is never dlclosed (process-lifetime), so the raw handle stays valid.
+unsafe impl Sync for RealLib {}
 
-impl Drop for RealLib {
-    fn drop(&mut self) {
-        unsafe {
-            if !self.handle.is_null() {
-                libc::dlclose(self.handle);
-            }
-        }
-    }
-}
-
-static INIT: Lazy<Mutex<Option<RealLib>>> = Lazy::new(|| Mutex::new(None));
-static INIT_FAILED: AtomicBool = AtomicBool::new(false);
+// One-time init WITHOUT holding a lock across real-library calls. HCCL/MSProf calls
+// re-enter the shim's exported `Msprof*` symbols; a held mutex here would deadlock
+// (parking_lot::Mutex is not reentrant), which manifested as aclprofStart hanging.
+static REAL: OnceCell<Option<RealLib>> = OnceCell::new();
 static LOGGED_INIT: AtomicBool = AtomicBool::new(false);
 
 const ENV_REAL: &str = "PROBING_HCCL_PROFAPI_REAL";
@@ -134,6 +171,30 @@ unsafe fn open_real() -> Option<RealLib> {
             report_additional: load_sym(handle, c"MsprofReportAdditionalInfo")?,
             get_hash_id: load_sym(handle, c"MsprofGetHashId")?,
             sys_cycle_time: load_sym(handle, c"MsprofSysCycleTime")?,
+            report_data: load_sym(handle, c"MsprofReportData"),
+            init: load_sym(handle, c"MsprofInit"),
+            finalize: load_sym(handle, c"MsprofFinalize"),
+            start: load_sym(handle, c"MsprofStart"),
+            stop: load_sym(handle, c"MsprofStop"),
+            notify_set_device: load_sym(handle, c"MsprofNotifySetDevice"),
+            register_profile_callback: load_sym(handle, c"MsprofRegisterProfileCallback"),
+            set_config: load_sym(handle, c"MsprofSetConfig"),
+            report_event: load_sym(handle, c"MsprofReportEvent"),
+            report_batch_additional: load_sym(handle, c"MsprofReportBatchAdditionalInfo"),
+            get_batch_max: load_sym(handle, c"MsprofGetBatchReportMaxSize"),
+            reg_data_format: load_sym(handle, c"MsprofRegDataFormat"),
+            str2id: load_sym(handle, c"MsprofStr2Id"),
+            set_device_by_ge: load_sym(handle, c"MsprofSetDeviceIdByGeModelIdx"),
+            unset_device_by_ge: load_sym(handle, c"MsprofUnsetDeviceIdByGeModelIdx"),
+            host_freq_is_enable: load_sym(handle, c"MsprofHostFreqIsEnable"),
+            subscribe_raw: load_sym(handle, c"MsprofSubscribeRawData"),
+            unsubscribe_raw: load_sym(handle, c"MsprofUnSubscribeRawData"),
+            prof_reg_reporter: load_sym(handle, c"profRegReporterCallback"),
+            prof_reg_ctrl: load_sym(handle, c"profRegCtrlCallback"),
+            prof_reg_device_state: load_sym(handle, c"profRegDeviceStateCallback"),
+            prof_get_device_by_ge: load_sym(handle, c"profGetDeviceIdByGeModelIdx"),
+            prof_set_command: load_sym(handle, c"profSetProfCommand"),
+            prof_set_step_info: load_sym(handle, c"profSetStepInfo"),
         };
         log_once(&format!("forwarding to {}", path.display()));
         return Some(RealLib { handle, api });
@@ -141,26 +202,22 @@ unsafe fn open_real() -> Option<RealLib> {
     None
 }
 
-fn real_lib() -> Option<parking_lot::MutexGuard<'static, Option<RealLib>>> {
-    let mut guard = INIT.lock();
-    if guard.is_none() && !INIT_FAILED.load(Ordering::Relaxed) {
-        unsafe {
-            *guard = open_real();
-        }
-        if guard.is_none() {
-            INIT_FAILED.store(true, Ordering::Relaxed);
-            if LOGGED_INIT
+fn real_api() -> Option<&'static RealApi> {
+    let slot = REAL.get_or_init(|| {
+        let lib = unsafe { open_real() };
+        if lib.is_none()
+            && LOGGED_INIT
                 .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
                 .is_ok()
-            {
-                crate::log::warn(format!(
-                    "real libprofapi not found; MSProf forward disabled. \
-                     Set {ENV_REAL} or place {REAL_BASENAME} next to the shim."
-                ));
-            }
+        {
+            crate::log::warn(format!(
+                "real libprofapi not found; MSProf forward disabled. \
+                 Set {ENV_REAL} or place {REAL_BASENAME} next to the shim."
+            ));
         }
-    }
-    Some(guard)
+        lib
+    });
+    slot.as_ref().map(|lib| &lib.api)
 }
 
 unsafe extern "C" fn stub_register(_: u32, _: ProfCommandHandle) -> i32 {
@@ -183,46 +240,36 @@ unsafe extern "C" fn stub_time() -> u64 {
 }
 
 pub fn forward_register(module_id: u32, handle: ProfCommandHandle) -> i32 {
-    if let Some(guard) = real_lib() {
-        if let Some(real) = guard.as_ref() {
-            return unsafe { (real.api.register_callback)(module_id, handle) };
-        }
+    if let Some(api) = real_api() {
+        return unsafe { (api.register_callback)(module_id, handle) };
     }
     unsafe { stub_register(module_id, handle) }
 }
 
 pub fn forward_reg_type_info(level: u16, type_id: u32, type_name: *const c_char) -> i32 {
-    if let Some(guard) = real_lib() {
-        if let Some(real) = guard.as_ref() {
-            return unsafe { (real.api.reg_type_info)(level, type_id, type_name) };
-        }
+    if let Some(api) = real_api() {
+        return unsafe { (api.reg_type_info)(level, type_id, type_name) };
     }
     unsafe { stub_reg_type(level, type_id, type_name) }
 }
 
-pub fn forward_report_api(aging: u32, api: *const c_void) -> i32 {
-    if let Some(guard) = real_lib() {
-        if let Some(real) = guard.as_ref() {
-            return unsafe { (real.api.report_api)(aging, api) };
-        }
+pub fn forward_report_api(aging: u32, api_ptr: *const c_void) -> i32 {
+    if let Some(api) = real_api() {
+        return unsafe { (api.report_api)(aging, api_ptr) };
     }
-    unsafe { stub_report_api(aging, api) }
+    unsafe { stub_report_api(aging, api_ptr) }
 }
 
 pub fn forward_report_compact(aging: u32, data: *const c_void, len: u32) -> i32 {
-    if let Some(guard) = real_lib() {
-        if let Some(real) = guard.as_ref() {
-            return unsafe { (real.api.report_compact)(aging, data, len) };
-        }
+    if let Some(api) = real_api() {
+        return unsafe { (api.report_compact)(aging, data, len) };
     }
     unsafe { stub_report_blob(aging, data, len) }
 }
 
 pub fn forward_report_additional(aging: u32, data: *const c_void, len: u32) -> i32 {
-    if let Some(guard) = real_lib() {
-        if let Some(real) = guard.as_ref() {
-            return unsafe { (real.api.report_additional)(aging, data, len) };
-        }
+    if let Some(api) = real_api() {
+        return unsafe { (api.report_additional)(aging, data, len) };
     }
     unsafe { stub_report_blob(aging, data, len) }
 }
@@ -231,19 +278,126 @@ pub fn forward_get_hash_id(hash_info: *const c_char, length: u32) -> u64 {
     if hash_info.is_null() || length == 0 {
         return 0;
     }
-    if let Some(guard) = real_lib() {
-        if let Some(real) = guard.as_ref() {
-            return unsafe { (real.api.get_hash_id)(hash_info, length) };
-        }
+    if let Some(api) = real_api() {
+        return unsafe { (api.get_hash_id)(hash_info, length) };
     }
     unsafe { stub_hash(hash_info, length) }
 }
 
 pub fn forward_sys_cycle_time() -> u64 {
-    if let Some(guard) = real_lib() {
-        if let Some(real) = guard.as_ref() {
-            return unsafe { (real.api.sys_cycle_time)() };
-        }
+    if let Some(api) = real_api() {
+        return unsafe { (api.sys_cycle_time)() };
     }
     unsafe { stub_time() }
+}
+
+macro_rules! forward_opt {
+    ($field:ident, $stub:expr, $($arg:expr),* $(,)?) => {{
+        if let Some(api) = real_api() {
+            if let Some(f) = api.$field {
+                return unsafe { f($($arg),*) };
+            }
+        }
+        $stub
+    }};
+}
+
+pub fn forward_report_data(module_id: u32, ty: u32, data: *mut c_void, len: u32) -> i32 {
+    forward_opt!(report_data, 0, module_id, ty, data, len)
+}
+
+pub fn forward_init(data_type: u32, data: *mut c_void, data_len: u32) -> i32 {
+    forward_opt!(init, 0, data_type, data, data_len)
+}
+
+pub fn forward_finalize() -> i32 {
+    forward_opt!(finalize, 0,)
+}
+
+pub fn forward_start(data_type: u32, data: *const c_void, length: u32) -> i32 {
+    forward_opt!(start, 0, data_type, data, length)
+}
+
+pub fn forward_stop(data_type: u32, data: *const c_void, length: u32) -> i32 {
+    forward_opt!(stop, 0, data_type, data, length)
+}
+
+pub fn forward_notify_set_device(chip_id: u32, device_id: u32, is_open: bool) -> i32 {
+    forward_opt!(notify_set_device, 0, chip_id, device_id, is_open)
+}
+
+pub fn forward_register_profile_callback(cb_type: i32, callback: *mut c_void, len: u32) -> i32 {
+    forward_opt!(register_profile_callback, 0, cb_type, callback, len)
+}
+
+pub fn forward_set_config(config_type: u32, config: *const c_char, config_length: usize) -> i32 {
+    forward_opt!(set_config, 0, config_type, config, config_length)
+}
+
+pub fn forward_report_event(aging: u32, event: *const c_void) -> i32 {
+    forward_opt!(report_event, 0, aging, event)
+}
+
+pub fn forward_report_batch_additional(aging: u32, data: *const c_void, len: u32) -> i32 {
+    forward_opt!(report_batch_additional, 0, aging, data, len)
+}
+
+pub fn forward_get_batch_max(ty: u32) -> usize {
+    forward_opt!(get_batch_max, 0, ty)
+}
+
+pub fn forward_reg_data_format(level: u16, type_id: u32, data_format: *const c_char) -> i32 {
+    forward_opt!(reg_data_format, 0, level, type_id, data_format)
+}
+
+pub fn forward_str2id(hash_info: *const c_char, length: usize) -> u64 {
+    forward_opt!(str2id, 0, hash_info, length)
+}
+
+pub fn forward_set_device_by_ge(ge_model_idx: u32, device_id: u32) -> i32 {
+    forward_opt!(set_device_by_ge, 0, ge_model_idx, device_id)
+}
+
+pub fn forward_unset_device_by_ge(ge_model_idx: u32, device_id: u32) -> i32 {
+    forward_opt!(unset_device_by_ge, 0, ge_model_idx, device_id)
+}
+
+pub fn forward_host_freq_is_enable() -> bool {
+    forward_opt!(host_freq_is_enable, false,)
+}
+
+pub fn forward_subscribe_raw(cb: FnRawCb) -> i32 {
+    forward_opt!(subscribe_raw, 0, cb)
+}
+
+pub fn forward_unsubscribe_raw() -> i32 {
+    forward_opt!(unsubscribe_raw, 0,)
+}
+
+pub type ReportHandle = Option<unsafe extern "C" fn(u32, u32, *mut c_void, u32) -> i32>;
+pub type CtrlHandle = Option<unsafe extern "C" fn(u32, *mut c_void, u32) -> i32>;
+pub type DeviceStateHandle = Option<unsafe extern "C" fn(*mut c_void, u32) -> i32>;
+
+pub fn forward_prof_reg_reporter(reporter: ReportHandle) -> i32 {
+    forward_opt!(prof_reg_reporter, -1, reporter)
+}
+
+pub fn forward_prof_reg_ctrl(handle: CtrlHandle) -> i32 {
+    forward_opt!(prof_reg_ctrl, -1, handle)
+}
+
+pub fn forward_prof_reg_device_state(handle: DeviceStateHandle) -> i32 {
+    forward_opt!(prof_reg_device_state, -1, handle)
+}
+
+pub fn forward_prof_get_device_by_ge(model_idx: u32, device_id: *mut u32) -> i32 {
+    forward_opt!(prof_get_device_by_ge, -1, model_idx, device_id)
+}
+
+pub fn forward_prof_set_command(command: *mut c_void, len: u32) -> i32 {
+    forward_opt!(prof_set_command, -1, command, len)
+}
+
+pub fn forward_prof_set_step_info(index_id: u64, tag_id: u16, stream: *mut c_void) -> i32 {
+    forward_opt!(prof_set_step_info, -1, index_id, tag_id, stream)
 }

--- a/probing/extensions/hccl-shim/src/forward.rs
+++ b/probing/extensions/hccl-shim/src/forward.rs
@@ -62,9 +62,16 @@ struct RealApi {
     subscribe_raw: Option<FnSubscribe>,
     unsubscribe_raw: Option<FnI32>,
     // Atlas / ACL registration entry points (needed for acl.prof.init).
-    prof_reg_reporter: Option<unsafe extern "C" fn(Option<unsafe extern "C" fn(u32, u32, *mut c_void, u32) -> i32>) -> i32>,
-    prof_reg_ctrl: Option<unsafe extern "C" fn(Option<unsafe extern "C" fn(u32, *mut c_void, u32) -> i32>) -> i32>,
-    prof_reg_device_state: Option<unsafe extern "C" fn(Option<unsafe extern "C" fn(*mut c_void, u32) -> i32>) -> i32>,
+    prof_reg_reporter: Option<
+        unsafe extern "C" fn(
+            Option<unsafe extern "C" fn(u32, u32, *mut c_void, u32) -> i32>,
+        ) -> i32,
+    >,
+    prof_reg_ctrl: Option<
+        unsafe extern "C" fn(Option<unsafe extern "C" fn(u32, *mut c_void, u32) -> i32>) -> i32,
+    >,
+    prof_reg_device_state:
+        Option<unsafe extern "C" fn(Option<unsafe extern "C" fn(*mut c_void, u32) -> i32>) -> i32>,
     prof_get_device_by_ge: Option<unsafe extern "C" fn(u32, *mut u32) -> i32>,
     prof_set_command: Option<unsafe extern "C" fn(*mut c_void, u32) -> i32>,
     prof_set_step_info: Option<unsafe extern "C" fn(u64, u16, *mut c_void) -> i32>,

--- a/probing/extensions/hccl-shim/src/lib.rs
+++ b/probing/extensions/hccl-shim/src/lib.rs
@@ -215,20 +215,12 @@ mod export {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn MsprofStart(
-        data_type: u32,
-        data: *const c_void,
-        length: u32,
-    ) -> i32 {
+    pub unsafe extern "C" fn MsprofStart(data_type: u32, data: *const c_void, length: u32) -> i32 {
         forward::forward_start(data_type, data, length)
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn MsprofStop(
-        data_type: u32,
-        data: *const c_void,
-        length: u32,
-    ) -> i32 {
+    pub unsafe extern "C" fn MsprofStop(data_type: u32, data: *const c_void, length: u32) -> i32 {
         forward::forward_stop(data_type, data, length)
     }
 
@@ -326,9 +318,7 @@ mod export {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn profRegReporterCallback(
-        reporter: forward::ReportHandle,
-    ) -> i32 {
+    pub unsafe extern "C" fn profRegReporterCallback(reporter: forward::ReportHandle) -> i32 {
         forward::forward_prof_reg_reporter(reporter)
     }
 
@@ -338,9 +328,7 @@ mod export {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn profRegDeviceStateCallback(
-        handle: forward::DeviceStateHandle,
-    ) -> i32 {
+    pub unsafe extern "C" fn profRegDeviceStateCallback(handle: forward::DeviceStateHandle) -> i32 {
         forward::forward_prof_reg_device_state(handle)
     }
 

--- a/probing/extensions/hccl-shim/src/lib.rs
+++ b/probing/extensions/hccl-shim/src/lib.rs
@@ -191,6 +191,180 @@ mod export {
     pub unsafe extern "C" fn MsprofSysCycleTime() -> u64 {
         forward::forward_sys_cycle_time()
     }
+
+    // Passthrough exports so Ascend runtime can resolve libprofapi when this shim
+    // is first on LD_LIBRARY_PATH (e.g. MsprofReportData from libruntime_common).
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofReportData(
+        module_id: u32,
+        ty: u32,
+        data: *mut c_void,
+        len: u32,
+    ) -> i32 {
+        forward::forward_report_data(module_id, ty, data, len)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofInit(data_type: u32, data: *mut c_void, data_len: u32) -> i32 {
+        forward::forward_init(data_type, data, data_len)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofFinalize() -> i32 {
+        forward::forward_finalize()
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofStart(
+        data_type: u32,
+        data: *const c_void,
+        length: u32,
+    ) -> i32 {
+        forward::forward_start(data_type, data, length)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofStop(
+        data_type: u32,
+        data: *const c_void,
+        length: u32,
+    ) -> i32 {
+        forward::forward_stop(data_type, data, length)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofNotifySetDevice(
+        chip_id: u32,
+        device_id: u32,
+        is_open: bool,
+    ) -> i32 {
+        forward::forward_notify_set_device(chip_id, device_id, is_open)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofRegisterProfileCallback(
+        callback_type: i32,
+        callback: *mut c_void,
+        len: u32,
+    ) -> i32 {
+        forward::forward_register_profile_callback(callback_type, callback, len)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofSetConfig(
+        config_type: u32,
+        config: *const c_char,
+        config_length: usize,
+    ) -> i32 {
+        forward::forward_set_config(config_type, config, config_length)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofReportEvent(aging_flag: u32, event: *const c_void) -> i32 {
+        forward::forward_report_event(aging_flag, event)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofReportBatchAdditionalInfo(
+        aging_flag: u32,
+        data: *const c_void,
+        length: u32,
+    ) -> i32 {
+        forward::forward_report_batch_additional(aging_flag, data, length)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofGetBatchReportMaxSize(ty: u32) -> usize {
+        forward::forward_get_batch_max(ty)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofRegDataFormat(
+        level: u16,
+        type_id: u32,
+        data_format: *const c_char,
+    ) -> i32 {
+        forward::forward_reg_data_format(level, type_id, data_format)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofStr2Id(hash_info: *const c_char, length: usize) -> u64 {
+        forward::forward_str2id(hash_info, length)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofSetDeviceIdByGeModelIdx(
+        ge_model_idx: u32,
+        device_id: u32,
+    ) -> i32 {
+        forward::forward_set_device_by_ge(ge_model_idx, device_id)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofUnsetDeviceIdByGeModelIdx(
+        ge_model_idx: u32,
+        device_id: u32,
+    ) -> i32 {
+        forward::forward_unset_device_by_ge(ge_model_idx, device_id)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofHostFreqIsEnable() -> bool {
+        forward::forward_host_freq_is_enable()
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofSubscribeRawData(
+        cb: Option<unsafe extern "C" fn(*mut c_void) -> i32>,
+    ) -> i32 {
+        forward::forward_subscribe_raw(cb)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn MsprofUnSubscribeRawData() -> i32 {
+        forward::forward_unsubscribe_raw()
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn profRegReporterCallback(
+        reporter: forward::ReportHandle,
+    ) -> i32 {
+        forward::forward_prof_reg_reporter(reporter)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn profRegCtrlCallback(handle: forward::CtrlHandle) -> i32 {
+        forward::forward_prof_reg_ctrl(handle)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn profRegDeviceStateCallback(
+        handle: forward::DeviceStateHandle,
+    ) -> i32 {
+        forward::forward_prof_reg_device_state(handle)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn profGetDeviceIdByGeModelIdx(
+        model_idx: u32,
+        device_id: *mut u32,
+    ) -> i32 {
+        forward::forward_prof_get_device_by_ge(model_idx, device_id)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn profSetProfCommand(command: *mut c_void, len: u32) -> i32 {
+        forward::forward_prof_set_command(command, len)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn profSetStepInfo(
+        index_id: u64,
+        tag_id: u16,
+        stream: *mut c_void,
+    ) -> i32 {
+        forward::forward_prof_set_step_info(index_id, tag_id, stream)
+    }
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/probing/extensions/hccl-shim/src/names.rs
+++ b/probing/extensions/hccl-shim/src/names.rs
@@ -118,7 +118,7 @@ pub fn register_hash_string(hash_info: *const c_char, length: u32, hash: u64) {
     if hash_info.is_null() || length == 0 || hash == 0 {
         return;
     }
-    let bytes = unsafe { std::slice::from_raw_parts(hash_info as *const u8, length as usize) };
+    let bytes = unsafe { std::slice::from_raw_parts(hash_info.cast::<u8>(), length as usize) };
     let Ok(name) = std::str::from_utf8(bytes) else {
         return;
     };

--- a/tests/regression/rust/probing/cli/inject_aarch64.rs
+++ b/tests/regression/rust/probing/cli/inject_aarch64.rs
@@ -29,6 +29,7 @@ fn injection_basic_fails_on_missing_library() {
     let result = Injector::attach(proc).and_then(|mut injector| injector.inject(dummy_lib, vec![]));
 
     let _ = target.kill();
+    let _ = target.wait();
 
     match result {
         Ok(_) => panic!("Expected injection to fail due to missing library"),


### PR DESCRIPTION
## Summary
- Replace the `parking_lot::Mutex` around real `libprofapi` loading with `OnceCell`, avoiding deadlock when HCCL/MSProf callbacks re-enter the shim's exported `Msprof*` symbols (previously hung at `aclprofStart`).
- Expand passthrough exports for additional `Msprof*` / `prof*` symbols so Ascend runtime can resolve `libprofapi` when the shim is first on `LD_LIBRARY_PATH`.

## Test plan
- [ ] Rebuild shim: `make hccl-shim-lib`
- [ ] Install real library / set `PROBING_HCCL_PROFAPI_REAL`, put shim dir first on `LD_LIBRARY_PATH`
- [ ] Run Ascend HCCL / `acl.prof` path and confirm `aclprofStart` no longer hangs
- [ ] Confirm probing still captures HCCL events into `hccl.*` tables


Made with [Cursor](https://cursor.com)