### PR TITLE
fix(extension): preserve distributed response quality

### DIFF
--- a/probing/core/src/core/error.rs
+++ b/probing/core/src/core/error.rs
@@ -59,6 +59,10 @@ pub enum EngineError {
     #[error("Unsupported API call")]
     UnsupportedCall,
 
+    /// Invalid external API call parameter.
+    #[error("Invalid API parameter: {0}={1}")]
+    InvalidCallParameter(String, String),
+
     // ===== Data Processing Errors =====
     /// Apache Arrow data processing error.
     #[error(transparent)]

--- a/probing/core/src/core/mod.rs
+++ b/probing/core/src/core/mod.rs
@@ -37,6 +37,7 @@ pub use probe_extension::ProbeExtension;
 pub use probe_extension::ProbeExtensionCall;
 pub use probe_extension::ProbeExtensionManager;
 pub use probe_extension::ProbeExtensionOption;
+pub use probe_extension::ProbeExtensionResponse;
 
 pub use probing_macros::ProbeExtension;
 

--- a/probing/core/src/core/probe_extension.rs
+++ b/probing/core/src/core/probe_extension.rs
@@ -77,6 +77,23 @@ pub struct ProbeExtensionOption {
     pub help: &'static str,
 }
 
+/// Body plus transport-neutral completeness metadata returned by an extension.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ProbeExtensionResponse {
+    pub body: Vec<u8>,
+    /// True when the body is usable but omits data from one or more peers.
+    pub partial: bool,
+}
+
+impl From<Vec<u8>> for ProbeExtensionResponse {
+    fn from(body: Vec<u8>) -> Self {
+        Self {
+            body,
+            partial: false,
+        }
+    }
+}
+
 /// Extension trait for handling HTTP API calls
 #[allow(unused)]
 #[async_trait]
@@ -98,6 +115,16 @@ pub trait ProbeExtensionCall: Debug + Send + Sync {
         body: &[u8],
     ) -> Result<Vec<u8>, EngineError> {
         Err(EngineError::UnsupportedCall)
+    }
+
+    /// Handle an API call while preserving response metadata for HTTP callers.
+    async fn call_response(
+        &self,
+        path: &str,
+        params: &HashMap<String, String>,
+        body: &[u8],
+    ) -> Result<ProbeExtensionResponse, EngineError> {
+        self.call(path, params, body).await.map(Into::into)
     }
 }
 
@@ -351,6 +378,17 @@ impl ProbeExtensionManager {
         params: &HashMap<String, String>,
         body: &[u8],
     ) -> Result<Vec<u8>, EngineError> {
+        self.call_response(path, params, body)
+            .await
+            .map(|response| response.body)
+    }
+
+    pub async fn call_response(
+        &self,
+        path: &str,
+        params: &HashMap<String, String>,
+        body: &[u8],
+    ) -> Result<ProbeExtensionResponse, EngineError> {
         let extensions_clone: Vec<_> = {
             let extensions = self.extensions.read().await;
             extensions.values().cloned().collect()
@@ -379,8 +417,8 @@ impl ProbeExtensionManager {
             log::debug!("checking extension [{name}]:{path}");
             log::debug!("Extension [{name}] matched, local_path: {}", local_path);
 
-            // Call the extension's async call method
-            match ext.call(&local_path, params, body).await {
+            // Call the extension while preserving response completeness metadata.
+            match ext.call_response(&local_path, params, body).await {
                 Ok(value) => return Ok(value),
                 Err(EngineError::UnsupportedCall) => {
                     log::debug!(
@@ -515,6 +553,49 @@ mod tests {
                 help: "Test option",
             }]
         }
+    }
+
+    #[derive(Debug)]
+    struct PartialResponseExtension;
+
+    #[async_trait]
+    impl ProbeExtensionCall for PartialResponseExtension {
+        async fn call_response(
+            &self,
+            _path: &str,
+            _params: &HashMap<String, String>,
+            _body: &[u8],
+        ) -> Result<ProbeExtensionResponse, EngineError> {
+            Ok(ProbeExtensionResponse {
+                body: b"partial".to_vec(),
+                partial: true,
+            })
+        }
+    }
+
+    impl ProbeExtension for PartialResponseExtension {
+        fn name(&self) -> String {
+            "partial".to_string()
+        }
+    }
+
+    #[tokio::test]
+    async fn call_response_preserves_extension_metadata() {
+        let mut manager = ProbeExtensionManager::default();
+        manager
+            .register(
+                "partial".to_string(),
+                Arc::new(Mutex::new(PartialResponseExtension)),
+            )
+            .await;
+
+        let response = manager
+            .call_response("/partial/data", &HashMap::new(), &[])
+            .await
+            .unwrap();
+
+        assert_eq!(response.body, b"partial");
+        assert!(response.partial);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/probing/extensions/python/src/extensions.rs
+++ b/probing/extensions/python/src/extensions.rs
@@ -2,6 +2,101 @@ mod pprof;
 pub mod python;
 mod torch;
 
+use std::collections::HashMap;
+
+use probing_core::core::EngineError;
+
 pub use pprof::PprofProbeExtension;
 pub use python::PythonExt;
 pub use torch::TorchProbeExtension;
+
+fn bool_param(
+    params: &HashMap<String, String>,
+    name: &str,
+    default: bool,
+) -> Result<bool, EngineError> {
+    match params.get(name).map(|value| value.trim()) {
+        None => Ok(default),
+        Some("1") => Ok(true),
+        Some("0") => Ok(false),
+        Some(value) if value.eq_ignore_ascii_case("true") => Ok(true),
+        Some(value) if value.eq_ignore_ascii_case("false") => Ok(false),
+        Some(value) => Err(EngineError::InvalidCallParameter(
+            name.to_string(),
+            value.to_string(),
+        )),
+    }
+}
+
+fn optional_i64_param(
+    params: &HashMap<String, String>,
+    name: &str,
+) -> Result<Option<i64>, EngineError> {
+    params
+        .get(name)
+        .map(|value| {
+            value
+                .parse::<i64>()
+                .map_err(|_| EngineError::InvalidCallParameter(name.to_string(), value.clone()))
+        })
+        .transpose()
+}
+
+fn one_of_param<'a>(
+    params: &'a HashMap<String, String>,
+    name: &str,
+    default: &'a str,
+    allowed: &[&str],
+) -> Result<&'a str, EngineError> {
+    let value = params.get(name).map(String::as_str).unwrap_or(default);
+    if allowed.contains(&value) {
+        Ok(value)
+    } else {
+        Err(EngineError::InvalidCallParameter(
+            name.to_string(),
+            value.to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_params_reject_invalid_values() {
+        let params = HashMap::from([
+            ("cluster".to_string(), "sometimes".to_string()),
+            ("step".to_string(), "latest".to_string()),
+            ("mode".to_string(), "native".to_string()),
+        ]);
+
+        assert!(matches!(
+            bool_param(&params, "cluster", true),
+            Err(EngineError::InvalidCallParameter(_, _))
+        ));
+        assert!(matches!(
+            optional_i64_param(&params, "step"),
+            Err(EngineError::InvalidCallParameter(_, _))
+        ));
+        assert!(matches!(
+            one_of_param(&params, "mode", "mixed", &["mixed", "py"]),
+            Err(EngineError::InvalidCallParameter(_, _))
+        ));
+    }
+
+    #[test]
+    fn query_params_accept_documented_values_and_defaults() {
+        let params = HashMap::from([
+            ("cluster".to_string(), "0".to_string()),
+            ("step".to_string(), "42".to_string()),
+        ]);
+
+        assert!(!bool_param(&params, "cluster", true).unwrap());
+        assert_eq!(optional_i64_param(&params, "step").unwrap(), Some(42));
+        assert_eq!(
+            one_of_param(&params, "mode", "mixed", &["mixed", "py"]).unwrap(),
+            "mixed"
+        );
+    }
+}

--- a/probing/extensions/python/src/extensions/pprof.rs
+++ b/probing/extensions/python/src/extensions/pprof.rs
@@ -6,6 +6,7 @@ use probing_core::core::Maybe;
 use probing_core::core::ProbeExtension;
 use probing_core::core::ProbeExtensionCall;
 use probing_core::core::ProbeExtensionOption;
+use probing_core::core::ProbeExtensionResponse;
 
 #[derive(Debug, Default, ProbeExtension)]
 pub struct PprofProbeExtension {
@@ -33,24 +34,44 @@ impl ProbeExtensionCall for PprofProbeExtension {
                 Ok(crate::features::stacktrace::tracers::pprof::folded_lines_json().into_bytes())
             }
             "flamegraph/distributed/json" => {
-                let cluster = params
-                    .get("cluster")
-                    .map(|v| v.as_str())
-                    .map(|v| v != "0" && v != "false")
-                    .unwrap_or(true);
-                let mode = params.get("mode").map(|s| s.as_str()).unwrap_or("mixed");
-                let (body, _) = crate::features::stacktrace::tracers::pprof::collect_distributed_stack_flamegraph_json(
-                    cluster, mode,
-                )
-                .await;
-                Ok(body.into_bytes())
+                Ok(self.distributed_flamegraph_response(params).await?.body)
             }
             _ => Err(EngineError::UnsupportedCall),
         }
     }
+
+    async fn call_response(
+        &self,
+        path: &str,
+        params: &HashMap<String, String>,
+        body: &[u8],
+    ) -> Result<ProbeExtensionResponse, EngineError> {
+        if path.trim_start_matches('/') != "flamegraph/distributed/json" {
+            return self.call(path, params, body).await.map(Into::into);
+        }
+
+        self.distributed_flamegraph_response(params).await
+    }
 }
 
 impl PprofProbeExtension {
+    async fn distributed_flamegraph_response(
+        &self,
+        params: &HashMap<String, String>,
+    ) -> Result<ProbeExtensionResponse, EngineError> {
+        let cluster = super::bool_param(params, "cluster", true)?;
+        let mode = super::one_of_param(params, "mode", "mixed", &["mixed", "py"])?;
+        let (body, partial) =
+            crate::features::stacktrace::tracers::pprof::collect_distributed_stack_flamegraph_json(
+                cluster, mode,
+            )
+            .await;
+        Ok(ProbeExtensionResponse {
+            body: body.into_bytes(),
+            partial,
+        })
+    }
+
     fn set_sample_freq(&mut self, pprof_sample_freq: Maybe<i32>) -> Result<(), EngineError> {
         // Clearing the option (`set probing.pprof.sample_freq=;`) or a value < 1
         // disables sampling and tears the sampler down.

--- a/probing/extensions/python/src/extensions/torch.rs
+++ b/probing/extensions/python/src/extensions/torch.rs
@@ -6,6 +6,7 @@ use probing_core::core::Maybe;
 use probing_core::core::ProbeExtension;
 use probing_core::core::ProbeExtensionCall;
 use probing_core::core::ProbeExtensionOption;
+use probing_core::core::ProbeExtensionResponse;
 use pyo3::prelude::*;
 
 #[derive(Debug, Default, ProbeExtension)]
@@ -30,24 +31,53 @@ impl ProbeExtensionCall for TorchProbeExtension {
                 Ok(crate::features::torch::flamegraph_json(metric).into_bytes())
             }
             "flamegraph/distributed/json" => {
-                let cluster = params
-                    .get("cluster")
-                    .map(|v| v.as_str())
-                    .map(|v| v != "0" && v != "false")
-                    .unwrap_or(true);
-                let step = params.get("step").and_then(|s| s.parse::<i64>().ok());
-                let metric = params.get("metric").map(|s| s.as_str());
-                crate::features::torch::collect_distributed_flamegraph_json(cluster, step, metric)
-                    .await
-                    .map(|body| body.into_bytes())
-                    .map_err(|e| EngineError::CallError(e.to_string()))
+                Ok(self.distributed_flamegraph_response(params).await?.body)
             }
             _ => Err(EngineError::UnsupportedCall),
         }
     }
+
+    async fn call_response(
+        &self,
+        path: &str,
+        params: &HashMap<String, String>,
+        body: &[u8],
+    ) -> Result<ProbeExtensionResponse, EngineError> {
+        if path.trim_start_matches('/') != "flamegraph/distributed/json" {
+            return self.call(path, params, body).await.map(Into::into);
+        }
+
+        self.distributed_flamegraph_response(params).await
+    }
 }
 
 impl TorchProbeExtension {
+    async fn distributed_flamegraph_response(
+        &self,
+        params: &HashMap<String, String>,
+    ) -> Result<ProbeExtensionResponse, EngineError> {
+        let cluster = super::bool_param(params, "cluster", true)?;
+        let step = super::optional_i64_param(params, "step")?;
+        let metric = super::one_of_param(
+            params,
+            "metric",
+            "duration",
+            &[
+                "duration", "delta_mb", "memory", "delta", "mem", "peak_mb", "peak",
+            ],
+        )?;
+        let (body, partial) = crate::features::torch::collect_distributed_flamegraph_json(
+            cluster,
+            step,
+            Some(metric),
+        )
+        .await?;
+        Ok(ProbeExtensionResponse {
+            body: body.into_bytes(),
+            partial,
+        })
+    }
+
     fn set_profiling(&mut self, profiling: Maybe<String>) -> Result<(), EngineError> {
         let py_result = Python::attach(|py| -> pyo3::PyResult<()> {
             let module = py.import("probing.profiling.torch_probe")?;

--- a/probing/extensions/python/src/features/torch/mod.rs
+++ b/probing/extensions/python/src/features/torch/mod.rs
@@ -956,22 +956,26 @@ pub async fn collect_distributed_flamegraph_json(
     cluster: bool,
     step: Option<i64>,
     metric: Option<&str>,
-) -> anyhow::Result<String> {
+) -> probing_core::core::Result<(String, bool)> {
     let table = if cluster {
         "global.python.torch_trace"
     } else {
         "python.torch_trace"
     };
     let sql = distributed_torch_trace_sql(table, step);
+    probing_core::core::federation::reset_fanout_stats();
     let engine = probing_core::ENGINE.read().await;
-    let dataframe = engine
-        .async_query(&sql)
-        .await
-        .context("distributed torch flamegraph query failed")?
-        .ok_or_else(|| {
-            anyhow::anyhow!("engine returned no dataframe for distributed torch query")
-        })?;
-    Ok(distributed_flamegraph_json_from_df(&dataframe, metric))
+    let query_result = engine.async_query(&sql).await;
+    let stats = probing_core::core::federation::take_fanout_stats();
+    let dataframe = query_result?.ok_or_else(|| {
+        probing_core::core::EngineError::internal(
+            "engine returned no dataframe for distributed torch query",
+        )
+    })?;
+    Ok((
+        distributed_flamegraph_json_from_df(&dataframe, metric),
+        probing_core::core::federation::fanout_stats_partial(&stats),
+    ))
 }
 
 /// JSON flamegraph from a federated or local ``torch_trace`` snapshot at one ``local_step``.

--- a/probing/server/API.md
+++ b/probing/server/API.md
@@ -35,7 +35,7 @@ Flamegraphs are served by profiler extensions (extension fallback, not public ro
 |--------|------|-------|
 | GET | `/apis/torchextension/flamegraph` | PyTorch module flamegraph (interactive HTML) |
 | GET | `/apis/torchextension/flamegraph/json` | JSON for native Web UI (`?metric=` optional) |
-| GET | `/apis/torchextension/flamegraph/distributed/json` | SPMD torch module flamegraph at one `local_step` (`?cluster=true` default, `?step=`, `?metric=`) |
+| GET | `/apis/torchextension/flamegraph/distributed/json` | SPMD torch module flamegraph at one `local_step` (`?cluster=true` default, `?step=`, `?metric=`). Requires the query engine to be ready. |
 | GET | `/apis/pprofextension/flamegraph` | CPU sampling flamegraph (interactive HTML) |
 | GET | `/apis/pprofextension/flamegraph/json` | JSON for native Web UI |
 | GET | `/apis/pprofextension/flamegraph/folded/json` | Raw folded stack lines for cluster merge |
@@ -218,7 +218,8 @@ envelope and these documented endpoint-specific formats.
 | Invalid `/query` JSON body | 400 |
 | SQL/config execution failure on `/query` | 500 (`QueryDataFormat::Error` payload preserved) |
 | `/query/dto` engine errors | Same HTTP status as underlying `ApiError` (e.g. 404, 503); DTO `code` mirrors status (`BAD_REQUEST`, `NOT_FOUND`, `SERVICE_UNAVAILABLE`, …) |
-| Partial cluster fan-out (`meta.partial` / `nodes_failed` non-empty) on `/query`, `/query/dto`, `POST /apis/cluster/query`, `GET /apis/training/step_matrix` | 503 (body still returned so clients can inspect partial data) |
+| Partial cluster fan-out (`meta.partial` / `nodes_failed` non-empty) on `/query`, `/query/dto`, `POST /apis/cluster/query`, `GET /apis/training/step_matrix`, or a distributed Torch/pprof flamegraph | 503 (body still returned so clients can inspect partial data) |
+| Invalid extension query parameter (`cluster`, `step`, `metric`, or `mode`) | 400 |
 | Invalid file path / missing param | 400 |
 | File too large | 413 |
 

--- a/probing/server/src/server/api/extension.rs
+++ b/probing/server/src/server/api/extension.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use http_body_util::BodyExt;
 
-use probing_core::core::ProbeExtensionManager;
+use probing_core::core::{ProbeExtensionManager, ProbeExtensionResponse};
 
 use crate::engine::ENGINE;
 use crate::server::api::response;
@@ -29,6 +29,11 @@ pub async fn handle(req: axum::extract::Request) -> ApiResult<Response> {
                 "Method {method} not allowed for {path}; expected {}",
                 route.method
             )));
+        }
+        if route.requires_engine_ready {
+            if let Some(message) = crate::engine_lifecycle::engine_not_ready_message() {
+                return Err(ApiError::service_unavailable(message));
+            }
         }
     }
 
@@ -61,8 +66,8 @@ pub async fn handle(req: axum::extract::Request) -> ApiResult<Response> {
         return Ok((StatusCode::NOT_FOUND, "Extension manager not available").into_response());
     };
 
-    match eem.call(path, &params, &body_bytes).await {
-        Ok(response_bytes) => Ok(extension_response(path, response_bytes).into_response()),
+    match eem.call_response(path, &params, &body_bytes).await {
+        Ok(extension) => Ok(extension_response(path, extension).into_response()),
         Err(e) => {
             log::error!("Extension call failed for path '{path}': {e}");
             Err(ApiError::from_engine(e))
@@ -75,12 +80,19 @@ pub fn api_path(full_path: &str) -> &str {
     full_path.strip_prefix("/apis").unwrap_or(full_path)
 }
 
-fn extension_response(path: &str, body: Vec<u8>) -> (StatusCode, HeaderMap, Vec<u8>) {
+fn extension_response(
+    path: &str,
+    response: ProbeExtensionResponse,
+) -> (StatusCode, HeaderMap, Vec<u8>) {
     let meta = response::lookup(path);
-    let status = response::status_for_extension_body(meta.content_type, &body);
+    let status = if response.partial {
+        StatusCode::SERVICE_UNAVAILABLE
+    } else {
+        response::status_for_extension_body(meta.content_type, &response.body)
+    };
     let mut headers = HeaderMap::new();
     response::apply_response_headers(meta, &mut headers);
-    (status, headers, body)
+    (status, headers, response.body)
 }
 
 fn cors_preflight() -> (StatusCode, HeaderMap, &'static str) {
@@ -95,11 +107,12 @@ fn cors_preflight() -> (StatusCode, HeaderMap, &'static str) {
 
 #[cfg(test)]
 mod tests {
-    use super::api_path;
+    use super::{api_path, extension_response};
     use crate::server::api::response::{
         lookup, route_spec, status_for_extension_body, ResponseMeta,
     };
     use axum::http::StatusCode;
+    use probing_core::core::ProbeExtensionResponse;
 
     fn load_spec() -> serde_json::Value {
         let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -120,6 +133,14 @@ mod tests {
     fn eval_route_is_post_in_spec() {
         let route = route_spec("/pythonext/eval").expect("eval route");
         assert_eq!(route.method, "POST");
+        assert!(!route.requires_engine_ready);
+    }
+
+    #[test]
+    fn distributed_torch_route_requires_ready_engine() {
+        let route = route_spec("/torchextension/flamegraph/distributed/json")
+            .expect("distributed torch route");
+        assert!(route.requires_engine_ready);
     }
 
     #[test]
@@ -154,6 +175,19 @@ mod tests {
                 br#"{"error":"No handler found for path: x"}"#
             ),
             StatusCode::NOT_FOUND
+        );
+    }
+
+    #[test]
+    fn partial_extension_response_maps_to_service_unavailable() {
+        let response = ProbeExtensionResponse {
+            body: br#"{"frames":[]}"#.to_vec(),
+            partial: true,
+        };
+
+        assert_eq!(
+            extension_response("/torchextension/flamegraph/distributed/json", response).0,
+            StatusCode::SERVICE_UNAVAILABLE
         );
     }
 }

--- a/probing/server/src/server/api/response.rs
+++ b/probing/server/src/server/api/response.rs
@@ -26,6 +26,7 @@ impl Default for ResponseMeta {
 pub struct ExtensionRouteSpec {
     pub method: &'static str,
     pub response: ResponseMeta,
+    pub requires_engine_ready: bool,
 }
 
 static ROUTE_MAP: Lazy<HashMap<String, ExtensionRouteSpec>> = Lazy::new(|| {
@@ -67,6 +68,10 @@ fn build_route_map() -> Result<HashMap<String, ExtensionRouteSpec>, String> {
             ExtensionRouteSpec {
                 method: parse_method(method),
                 response: parse_response_meta(response, &defaults),
+                requires_engine_ready: handler
+                    .get("requires_engine_ready")
+                    .and_then(|value| value.as_bool())
+                    .unwrap_or(false),
             },
         );
     }
@@ -93,6 +98,10 @@ fn build_route_map() -> Result<HashMap<String, ExtensionRouteSpec>, String> {
             ExtensionRouteSpec {
                 method: parse_method(method),
                 response: parse_response_meta(response, &defaults),
+                requires_engine_ready: entry
+                    .get("requires_engine_ready")
+                    .and_then(|value| value.as_bool())
+                    .unwrap_or(false),
             },
         );
     }

--- a/probing/server/src/server/error.rs
+++ b/probing/server/src/server/error.rs
@@ -71,6 +71,9 @@ impl ApiError {
         match err {
             EngineError::CallError(msg) | EngineError::PluginNotFound(msg) => Self::not_found(msg),
             EngineError::UnsupportedCall => Self::not_found("Unsupported API call"),
+            EngineError::InvalidCallParameter(name, value) => {
+                Self::bad_request(format!("Invalid API parameter: {name}={value}"))
+            }
             EngineError::PluginError(msg) => Self::new(StatusCode::BAD_GATEWAY, msg),
             EngineError::QueryError(msg)
             | EngineError::InternalError(msg)
@@ -157,6 +160,15 @@ mod tests {
     fn engine_plugin_error_maps_to_bad_gateway() {
         let err = ApiError::from_engine(EngineError::PluginError("boom".into()));
         assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[test]
+    fn invalid_call_parameter_maps_to_bad_request() {
+        let err = ApiError::from_engine(EngineError::InvalidCallParameter(
+            "cluster".into(),
+            "sometimes".into(),
+        ));
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/tests/regression/spec/api_spec.json
+++ b/tests/regression/spec/api_spec.json
@@ -400,6 +400,7 @@
       "method": "GET",
       "path": "/apis/torchextension/flamegraph/distributed/json",
       "local_path": "flamegraph/distributed/json",
+      "requires_engine_ready": true,
       "response": {
         "content_type": "application/json",
         "cors": false


### PR DESCRIPTION
Propagate partial fan-out metadata through ProbeExtensionResponse so HTTP callers receive 503 with the usable body intact. Preserve typed Torch query failures, validate profiler query parameters, and declare engine-readiness requirements in the API contract.