### PR TITLE
feat(megatron): visualize distributed training topology

### DIFF
--- a/examples/megatron/megatron_mcore_train_loop.py
+++ b/examples/megatron/megatron_mcore_train_loop.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Dict, Iterator, Tuple
 
 import probing
 import torch
+from probing.profiling.torch_probe import flush_torch_probes
 from torch.optim import Adam
 from torch.utils.data import DataLoader
 
@@ -319,7 +320,12 @@ def main() -> None:
         if args.max_duration_sec > 0 and (time.monotonic() - started) >= args.max_duration_sec:
             break
 
-        with probing.span("train_iter"):
+        sync_step_from_iteration(
+            iteration + 1,
+            micro_batches=args.num_microbatches,
+            force=True,
+        )
+        with probing.span("train.step"):
             optim.zero_grad()
             losses_reduced = forward_backward_func(
                 forward_step_func=forward_step_func,
@@ -333,11 +339,6 @@ def main() -> None:
             )
             finalize_model_grads([gpt_model])
             optim.step()
-            sync_step_from_iteration(
-                iteration + 1,
-                micro_batches=args.num_microbatches,
-                force=True,
-            )
             sync_role_from_parallel_state()
 
         if rank == 0 and (iteration + 1) % args.print_freq == 0:
@@ -351,6 +352,10 @@ def main() -> None:
         iteration += 1
         if args.step_sleep_ms > 0:
             time.sleep(args.step_sleep_ms / 1000.0)
+
+    # GPU-event rows intentionally trail the live step by a few iterations.
+    # Flush them once training becomes idle so the final steps remain queryable.
+    flush_torch_probes()
 
     if rank == 0 and not args.skip_checkpoint:
         ckpt_path = os.path.join(os.getcwd(), "ckpt")

--- a/probing/server/src/cluster_report_backoff.rs
+++ b/probing/server/src/cluster_report_backoff.rs
@@ -68,12 +68,16 @@ fn backoff_factor() -> f64 {
         .max(1.0_f64)
 }
 
-/// Cap interval below stale TTL so nodes are not marked dead between beats.
+/// Keep two heartbeat opportunities inside the stale TTL.
+///
+/// A single margin below the TTL is not enough when a report overlaps a busy
+/// training step or briefly retries its parent. Capping at half the threshold
+/// lets one report be delayed or lost without evicting a live rank.
 pub fn max_report_interval_secs() -> u64 {
     let base = base_report_interval_secs();
     let configured = configured_max_interval_secs();
     let stale = stale_threshold_secs();
-    let safe = stale.saturating_sub(stale / 4 + 1).max(base);
+    let safe = (stale / 2).max(base);
     configured.min(safe).max(base)
 }
 
@@ -258,7 +262,7 @@ mod tests {
                 ("PROBING_CLUSTER_REPORT_MAX_INTERVAL_SEC", "120"),
             ],
             || {
-                assert!(max_report_interval_secs() <= 25);
+                assert_eq!(max_report_interval_secs(), 12);
             },
         );
     }

--- a/probing/server/src/server/cluster_fanout/merge.rs
+++ b/probing/server/src/server/cluster_fanout/merge.rs
@@ -19,7 +19,7 @@ pub(super) fn merge_tagged_dataframes(parts: &[DataFrame]) -> DataFrame {
 
 #[cfg(test)]
 mod tests {
-    use probing_proto::prelude::{Seq, *};
+    use probing_proto::prelude::Seq;
 
     use super::*;
 

--- a/python/probing/ext/megatron.py
+++ b/python/probing/ext/megatron.py
@@ -13,11 +13,15 @@ from __future__ import annotations
 import functools
 import logging
 import os
+import re
 import sys
+import time
+from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
 import probing
 
+from probing.core.table import table
 from probing.util.env import FALSE_VALUES, TRUE_VALUES, parse_bool_flag
 
 logger = logging.getLogger(__name__)
@@ -26,6 +30,61 @@ _PARALLEL_STATE_INIT = False
 _TRAINING_INIT = False
 _LAST_ROLE: Optional[str] = None
 _LAST_ITERATION: Optional[int] = None
+_RECORDED_RANK_LAYOUTS: set[tuple[Any, ...]] = set()
+_CAPTURED_MODEL_IDS: set[int] = set()
+
+
+@table("megatron_rank_layout", capacity_bytes=2 * 1024 * 1024)
+@dataclass
+class MegatronRankLayout:
+    """Static Megatron parallel placement and layer ownership for one model chunk."""
+
+    recorded_at_ns: int
+    rank: int
+    world_size: int
+    local_rank: int
+    role: str
+    tp_rank: int
+    tp_size: int
+    pp_rank: int
+    pp_size: int
+    dp_rank: int
+    dp_size: int
+    cp_rank: int
+    cp_size: int
+    ep_rank: int
+    ep_size: int
+    vp_rank: int
+    vp_size: int
+    model_chunk: int
+    layer_start: int
+    layer_end: int
+    module_count: int
+    layout_key: str
+    is_first_pp_stage: int
+    is_last_pp_stage: int
+
+
+@table("megatron_module_catalog", capacity_bytes=16 * 1024 * 1024)
+@dataclass
+class MegatronModuleCatalog:
+    """Static module tree reported by one Megatron rank and model chunk."""
+
+    recorded_at_ns: int
+    rank: int
+    layout_key: str
+    model_chunk: int
+    module_path: str
+    parent_path: str
+    module_type: str
+    depth: int
+    local_layer_index: int
+    global_layer_index: int
+    parameter_count: int
+    trainable_parameter_count: int
+    dtype: str
+    device: str
+    is_leaf: int
 
 # Megatron-style env vars that indicate a Megatron job even before import.
 _MEGATRON_ENV_MARKERS = (
@@ -139,6 +198,259 @@ def role_dims_from_parallel_state(ps: Any) -> dict[str, int]:
     return dims
 
 
+def _parallel_value(ps: Any, names: tuple[str, ...], default: int = -1) -> int:
+    value = _call_rank_getter(ps, names)
+    return value if value is not None else default
+
+
+def _distributed_value(name: str, env_name: str, default: int = -1) -> int:
+    try:
+        import torch.distributed as dist
+
+        fn = getattr(dist, name, None)
+        if callable(fn) and dist.is_available() and dist.is_initialized():
+            return int(fn())
+    except Exception:
+        pass
+    value = _safe_int(os.environ.get(env_name))
+    return value if value is not None else default
+
+
+def _parallel_snapshot(ps: Any) -> dict[str, int]:
+    mapping = {
+        "tp_rank": ("get_tensor_model_parallel_rank",),
+        "tp_size": ("get_tensor_model_parallel_world_size",),
+        "pp_rank": ("get_pipeline_model_parallel_rank",),
+        "pp_size": ("get_pipeline_model_parallel_world_size",),
+        "dp_rank": ("get_data_parallel_rank",),
+        "dp_size": ("get_data_parallel_world_size",),
+        "cp_rank": ("get_context_parallel_rank",),
+        "cp_size": ("get_context_parallel_world_size",),
+        "ep_rank": ("get_expert_model_parallel_rank",),
+        "ep_size": ("get_expert_model_parallel_world_size",),
+        "vp_rank": ("get_virtual_pipeline_model_parallel_rank",),
+        "vp_size": ("get_virtual_pipeline_model_parallel_world_size",),
+    }
+    return {name: _parallel_value(ps, getters) for name, getters in mapping.items()}
+
+
+def _bool_getter(ps: Any, name: str) -> int:
+    fn = getattr(ps, name, None)
+    if not callable(fn):
+        return -1
+    try:
+        return int(bool(fn()))
+    except Exception:
+        return -1
+
+
+def _layout_key(snapshot: dict[str, int], model_chunk: int) -> str:
+    return ",".join(
+        (
+            f"pp={snapshot['pp_rank']}",
+            f"tp={snapshot['tp_rank']}",
+            f"ep={snapshot['ep_rank']}",
+            f"vp={snapshot['vp_rank']}",
+            f"chunk={model_chunk}",
+        )
+    )
+
+
+def _save_rank_layout(
+    ps: Any,
+    *,
+    model_chunk: int = -1,
+    layer_start: int = -1,
+    layer_end: int = -1,
+    module_count: int = 0,
+    recorded_at_ns: Optional[int] = None,
+) -> None:
+    snapshot = _parallel_snapshot(ps)
+    rank = _distributed_value("get_rank", "RANK")
+    world_size = _distributed_value("get_world_size", "WORLD_SIZE")
+    local_rank = _safe_int(os.environ.get("LOCAL_RANK"))
+    local_rank = local_rank if local_rank is not None else -1
+    signature = (
+        rank,
+        tuple(sorted(snapshot.items())),
+        model_chunk,
+        layer_start,
+        layer_end,
+        module_count,
+    )
+    if signature in _RECORDED_RANK_LAYOUTS:
+        return
+    _RECORDED_RANK_LAYOUTS.add(signature)
+    try:
+        MegatronRankLayout.append(
+            MegatronRankLayout(
+                recorded_at_ns=recorded_at_ns or time.time_ns(),
+                rank=rank,
+                world_size=world_size,
+                local_rank=local_rank,
+                role=probing.current_role(),
+                model_chunk=model_chunk,
+                layer_start=layer_start,
+                layer_end=layer_end,
+                module_count=module_count,
+                layout_key=_layout_key(snapshot, model_chunk),
+                is_first_pp_stage=_bool_getter(ps, "is_pipeline_first_stage"),
+                is_last_pp_stage=_bool_getter(ps, "is_pipeline_last_stage"),
+                **snapshot,
+            )
+        )
+    except Exception as exc:
+        _RECORDED_RANK_LAYOUTS.discard(signature)
+        logger.debug("Megatron rank layout capture skipped: %s", exc)
+
+
+_LAYER_PATH_RE = re.compile(r"(?:^|\.)(?:layers?|transformer_layers)\.(\d+)(?:\.|$)")
+
+
+def _local_layer_index(path: str) -> int:
+    match = _LAYER_PATH_RE.search(path)
+    return int(match.group(1)) if match else -1
+
+
+def _global_layer_index(module: Any) -> int:
+    for name in ("global_layer_number", "layer_number"):
+        value = _safe_int(getattr(module, name, None))
+        if value is not None:
+            # Megatron TransformerLayer.layer_number is conventionally one-based.
+            return max(0, value - 1) if name == "layer_number" else value
+    return -1
+
+
+def _direct_parameters(module: Any) -> list[Any]:
+    fn = getattr(module, "parameters", None)
+    if not callable(fn):
+        return []
+    try:
+        return list(fn(recurse=False))
+    except TypeError:
+        return []
+    except Exception:
+        return []
+
+
+def _parameter_count(parameters: list[Any], *, trainable_only: bool = False) -> int:
+    total = 0
+    for parameter in parameters:
+        if trainable_only and not bool(getattr(parameter, "requires_grad", False)):
+            continue
+        try:
+            total += int(parameter.numel())
+        except Exception:
+            continue
+    return total
+
+
+def _module_records(
+    model: Any,
+    *,
+    rank: int,
+    layout_key: str,
+    model_chunk: int,
+    recorded_at_ns: int,
+) -> list[MegatronModuleCatalog]:
+    named_modules = getattr(model, "named_modules", None)
+    if not callable(named_modules):
+        return []
+    try:
+        modules = list(named_modules())
+    except Exception:
+        return []
+
+    global_by_local: dict[int, int] = {}
+    for path, module in modules:
+        local = _local_layer_index(str(path))
+        global_index = _global_layer_index(module)
+        if local >= 0 and global_index >= 0:
+            global_by_local.setdefault(local, global_index)
+
+    records = []
+    for path, module in modules:
+        path = str(path)
+        local = _local_layer_index(path)
+        global_index = _global_layer_index(module)
+        if global_index < 0 and local >= 0:
+            global_index = global_by_local.get(local, -1)
+        parameters = _direct_parameters(module)
+        first_parameter = parameters[0] if parameters else None
+        try:
+            is_leaf = int(not any(True for _ in module.children()))
+        except Exception:
+            is_leaf = -1
+        records.append(
+            MegatronModuleCatalog(
+                recorded_at_ns=recorded_at_ns,
+                rank=rank,
+                layout_key=layout_key,
+                model_chunk=model_chunk,
+                module_path=path or "<root>",
+                parent_path=path.rsplit(".", 1)[0] if "." in path else "",
+                module_type=f"{type(module).__module__}.{type(module).__qualname__}",
+                depth=0 if not path else path.count(".") + 1,
+                local_layer_index=local,
+                global_layer_index=global_index,
+                parameter_count=_parameter_count(parameters),
+                trainable_parameter_count=_parameter_count(
+                    parameters, trainable_only=True
+                ),
+                dtype=str(getattr(first_parameter, "dtype", "")),
+                device=str(getattr(first_parameter, "device", "")),
+                is_leaf=is_leaf,
+            )
+        )
+    return records
+
+
+def capture_model_layout(models: Any, ps: Any | None = None) -> None:
+    """Persist a one-time static module catalog after Megatron builds the model."""
+    if ps is None:
+        try:
+            from megatron.core import parallel_state as ps  # type: ignore
+        except ImportError:
+            return
+    chunks = list(models) if isinstance(models, (list, tuple)) else [models]
+    rank = _distributed_value("get_rank", "RANK")
+    snapshot = _parallel_snapshot(ps)
+    recorded_at_ns = time.time_ns()
+    for chunk_index, model in enumerate(chunks):
+        identity = id(model)
+        if identity in _CAPTURED_MODEL_IDS:
+            continue
+        _CAPTURED_MODEL_IDS.add(identity)
+        key = _layout_key(snapshot, chunk_index)
+        records = _module_records(
+            model,
+            rank=rank,
+            layout_key=key,
+            model_chunk=chunk_index,
+            recorded_at_ns=recorded_at_ns,
+        )
+        if records:
+            try:
+                MegatronModuleCatalog.append_many(records)
+            except Exception as exc:
+                _CAPTURED_MODEL_IDS.discard(identity)
+                logger.debug("Megatron module catalog capture skipped: %s", exc)
+                continue
+        layer_indices = [
+            record.global_layer_index
+            for record in records
+            if record.global_layer_index >= 0
+        ]
+        _save_rank_layout(
+            ps,
+            model_chunk=chunk_index,
+            layer_start=min(layer_indices, default=-1),
+            layer_end=max(layer_indices, default=-1),
+            module_count=len(records),
+            recorded_at_ns=recorded_at_ns,
+        )
+
+
 def sync_role_from_parallel_state(ps: Any | None = None) -> Optional[str]:
     """Read Megatron parallel ranks and push them into ``probing.set_role``."""
     global _LAST_ROLE
@@ -153,6 +465,7 @@ def sync_role_from_parallel_state(ps: Any | None = None) -> Optional[str]:
         return None
 
     role = probing.set_role(**dims)
+    _save_rank_layout(ps)
     if role and role != _LAST_ROLE:
         logger.info("Megatron parallel role synced: %s", role)
         _LAST_ROLE = role
@@ -318,6 +631,22 @@ def _wrap_train_step(training_mod: Any) -> None:
     _wrap_callable(training_mod, "train_step", builder)
 
 
+def _wrap_get_model(training_mod: Any) -> None:
+    def builder(original):
+        @functools.wraps(original)
+        def wrapped(*args, **kwargs):
+            models = original(*args, **kwargs)
+            try:
+                capture_model_layout(models)
+            except Exception as exc:
+                logger.debug("Megatron model layout capture skipped: %s", exc)
+            return models
+
+        return wrapped
+
+    _wrap_callable(training_mod, "get_model", builder)
+
+
 def init_training() -> None:
     """Import-hook entry when ``megatron.training.training`` loads."""
     global _TRAINING_INIT
@@ -332,6 +661,7 @@ def init_training() -> None:
 
     if step_sync_enabled():
         _wrap_train_step(training_mod)
+    _wrap_get_model(training_mod)
     sync_step_from_megatron(force=True)
     sync_role_from_parallel_state()
 

--- a/python/probing/ext/megatron.py
+++ b/python/probing/ext/megatron.py
@@ -86,6 +86,7 @@ class MegatronModuleCatalog:
     device: str
     is_leaf: int
 
+
 # Megatron-style env vars that indicate a Megatron job even before import.
 _MEGATRON_ENV_MARKERS = (
     "TENSOR_MODEL_PARALLEL_RANK",

--- a/python/probing/profiling/torch_probe.py
+++ b/python/probing/profiling/torch_probe.py
@@ -1068,6 +1068,7 @@ class TorchProbe(BaseTracer, Timer, Sampler, PythonTracer, VariableTracer):
         self.pending = []
         self._open_spans = {}
         self._train_step_cm = None
+        self._optimizer_step_snapshot = None
         self._step_cycle = 0
         self.shadow_step = False
         self._step_wall_started_at: Optional[float] = None
@@ -1190,6 +1191,9 @@ class TorchProbe(BaseTracer, Timer, Sampler, PythonTracer, VariableTracer):
     def pre_step_hook(self, optimizer, args, kwargs):
         if self.shadow_step:
             return
+        # Preserve the optimizer-entry coordinate. Another hook may close the
+        # enclosing train-step span before our post hook runs.
+        self._optimizer_step_snapshot = step.snapshot()
         if self.enabled and self.finalized:
             self._begin_train_step_span(optimizer=optimizer)
         if not self._hooks_dispatch_active():
@@ -1347,7 +1351,8 @@ class TorchProbe(BaseTracer, Timer, Sampler, PythonTracer, VariableTracer):
         span_key = (id(mod), mapped_stage)
 
         record = mem_stats()
-        self._stamp_step_role(record)
+        snapshot = self._optimizer_step_snapshot if post_stage == "post step" else None
+        self._stamp_step_role(record, snapshot=snapshot)
         record.seq = self.offset()
         module_name_str = self._module_display_name(mod)
         record.module = module_name_str
@@ -1619,6 +1624,12 @@ class TorchProbe(BaseTracer, Timer, Sampler, PythonTracer, VariableTracer):
         ready = self._collect_ready_deferred()
         self._persist_deferred_records(ready)
 
+    def flush_deferred(self) -> None:
+        """Force all outstanding GPU-event records into the persistence queue."""
+        ready = [(record, True) for record in self._deferred]
+        self._deferred.clear()
+        self._persist_deferred_records(ready)
+
     def _close_step_wall(self, *, is_shadow: bool) -> None:
         """Record step wall time, then schedule deferred GPU trace persistence."""
         self._record_step_timing(is_shadow=is_shadow)
@@ -1630,6 +1641,7 @@ class TorchProbe(BaseTracer, Timer, Sampler, PythonTracer, VariableTracer):
 
     def post_step_hook(self, opt, args, kwargs):
         if not self.enabled:
+            self._optimizer_step_snapshot = None
             return
         if not self.finalized:
             self.finalize_discovery()
@@ -1638,6 +1650,7 @@ class TorchProbe(BaseTracer, Timer, Sampler, PythonTracer, VariableTracer):
             self.curr_step = step.micro_step
             self._mark_step_wall_start()
             self._begin_train_step_span(optimizer=opt)
+            self._optimizer_step_snapshot = None
             return
 
         if self.shadow_step:
@@ -1646,6 +1659,7 @@ class TorchProbe(BaseTracer, Timer, Sampler, PythonTracer, VariableTracer):
             self._cleanup_step_resources()
             self.step_start = None
             self._close_step_wall(is_shadow=True)
+            self._optimizer_step_snapshot = None
             return
 
         self._end_train_step_span()
@@ -1659,9 +1673,11 @@ class TorchProbe(BaseTracer, Timer, Sampler, PythonTracer, VariableTracer):
             self.step_start = None
             self.pending.clear()
             self._close_step_wall(is_shadow=False)
+            self._optimizer_step_snapshot = None
             return
 
         super().post_step_hook(opt, args, kwargs)
+        self._optimizer_step_snapshot = None
 
         self._finish_open_stages()
 
@@ -1690,6 +1706,18 @@ class TorchProbe(BaseTracer, Timer, Sampler, PythonTracer, VariableTracer):
         self._cleanup_step_resources()
         self.step_start = None
         self._close_step_wall(is_shadow=False)
+
+
+def flush_torch_probes(timeout: float = 10.0) -> None:
+    """Persist delayed TorchProbe rows during graceful training shutdown."""
+    tracers = _live_torch_probes()
+    if not tracers:
+        return
+    for tracer in tracers:
+        tracer.flush_deferred()
+    from probing.profiling.deferred_drain import flush_deferred_drain
+
+    flush_deferred_drain(timeout=timeout)
 
 
 def set_sampling_mode(mode):

--- a/tests/regression/ext/_megatron_contract.py
+++ b/tests/regression/ext/_megatron_contract.py
@@ -20,6 +20,9 @@ def make_parallel_state(
     tp: int = 2,
     pp: int = 1,
     dp: int = 3,
+    tp_size: int = 4,
+    pp_size: int = 2,
+    dp_size: int = 8,
 ) -> types.ModuleType:
     ps = types.ModuleType("megatron.core.parallel_state")
 
@@ -28,8 +31,17 @@ def make_parallel_state(
 
     ps.model_parallel_is_initialized = model_parallel_is_initialized
     ps.get_tensor_model_parallel_rank = lambda: tp
+    ps.get_tensor_model_parallel_world_size = lambda: tp_size
     ps.get_pipeline_model_parallel_rank = lambda: pp
+    ps.get_pipeline_model_parallel_world_size = lambda: pp_size
     ps.get_data_parallel_rank = lambda: dp
+    ps.get_data_parallel_world_size = lambda: dp_size
+    ps.get_context_parallel_world_size = lambda: 1
+    ps.get_expert_model_parallel_world_size = lambda: 1
+    ps.get_virtual_pipeline_model_parallel_rank = lambda: 0
+    ps.get_virtual_pipeline_model_parallel_world_size = lambda: 1
+    ps.is_pipeline_first_stage = lambda: pp == 0
+    ps.is_pipeline_last_stage = lambda: pp == pp_size - 1
     ps.initialize_model_parallel = lambda *args, **kwargs: None
     return ps
 

--- a/tests/regression/ext/conftest.py
+++ b/tests/regression/ext/conftest.py
@@ -35,6 +35,8 @@ def _reset_megatron_ext_state():
     megatron_ext._TRAINING_INIT = False
     megatron_ext._LAST_ROLE = None
     megatron_ext._LAST_ITERATION = None
+    megatron_ext._RECORDED_RANK_LAYOUTS.clear()
+    megatron_ext._CAPTURED_MODEL_IDS.clear()
     yield
     for key in list(sys.modules):
         if key == "megatron" or key.startswith("megatron."):

--- a/tests/regression/ext/test_megatron_contract.py
+++ b/tests/regression/ext/test_megatron_contract.py
@@ -155,6 +155,84 @@ def test_train_step_wrap_syncs_iteration(megatron_env):
         assert int(probing.step.snapshot().micro_batches) == 4
 
 
+def test_get_model_wrap_captures_static_layout(megatron_env):
+    ps = make_parallel_state()
+    modules = install_megatron_stack(ps=ps)
+    training_mod = modules["megatron.training.training"]
+    model = object()
+    training_mod.get_model = lambda: [model]
+
+    with megatron_modules(modules), mock.patch.object(
+        megatron_ext, "capture_model_layout"
+    ) as capture:
+        megatron_ext.init_training()
+        assert getattr(training_mod.get_model, "_probing_wrapped", False)
+        assert training_mod.get_model() == [model]
+        capture.assert_called_once_with([model])
+
+
+def test_capture_model_layout_records_rank_layers_and_modules(
+    megatron_env, monkeypatch
+):
+    class FakeParameter:
+        requires_grad = True
+        dtype = "float16"
+        device = "cuda:0"
+
+        def numel(self):
+            return 128
+
+    class FakeModule:
+        def __init__(self, *, layer_number=None, parameters=None):
+            self.layer_number = layer_number
+            self._parameters = parameters or []
+
+        def parameters(self, recurse=True):
+            return iter(self._parameters)
+
+        def children(self):
+            return iter(())
+
+    root = FakeModule()
+    layer = FakeModule(layer_number=5, parameters=[FakeParameter()])
+    root.named_modules = lambda: iter(
+        [
+            ("", root),
+            ("decoder.layers.0", layer),
+            ("decoder.layers.0.mlp", FakeModule()),
+        ]
+    )
+    ps = make_parallel_state(tp=1, pp=1, dp=2)
+    monkeypatch.setenv("RANK", "11")
+    monkeypatch.setenv("WORLD_SIZE", "64")
+    monkeypatch.setenv("LOCAL_RANK", "3")
+
+    with mock.patch.object(
+        megatron_ext.MegatronModuleCatalog, "append_many"
+    ) as append_modules, mock.patch.object(
+        megatron_ext.MegatronRankLayout, "append"
+    ) as append_layout:
+        megatron_ext.capture_model_layout(root, ps)
+
+    records = append_modules.call_args.args[0]
+    assert len(records) == 3
+    assert records[1].local_layer_index == 0
+    assert records[1].global_layer_index == 4
+    assert records[1].parameter_count == 128
+    assert records[2].global_layer_index == 4
+
+    layout = append_layout.call_args.args[0]
+    assert layout.rank == 11
+    assert layout.local_rank == 3
+    assert layout.tp_rank == 1
+    assert layout.tp_size == 4
+    assert layout.pp_rank == 1
+    assert layout.pp_size == 2
+    assert layout.layer_start == 4
+    assert layout.layer_end == 4
+    assert layout.module_count == 3
+
+
 def test_sync_step_from_iteration(megatron_env):
     megatron_ext.sync_step_from_iteration(7, micro_batches=4, force=True)
     assert probing.step.local_step == 7

--- a/tests/regression/profiling/test_torch_probe_sampling.py
+++ b/tests/regression/profiling/test_torch_probe_sampling.py
@@ -191,6 +191,23 @@ def test_post_step_hook_drains_deferred_after_step_timing(monkeypatch):
     assert order[-4:] == ["timing", "drain", "advance", "mark"]
 
 
+def test_graceful_flush_forces_all_deferred_records(monkeypatch):
+    tracer, _, _ = _ready_tracer()
+    records = [object(), object()]
+    persisted = []
+    tracer._deferred = records.copy()
+    monkeypatch.setattr(
+        tracer,
+        "_persist_deferred_records",
+        lambda ready: persisted.extend(ready),
+    )
+
+    tracer.flush_deferred()
+
+    assert tracer._deferred == []
+    assert persisted == [(records[0], True), (records[1], True)]
+
+
 def test_anchor_pre_always_pairs_post_even_when_layer_not_sampled():
     # layer_rate=0 → nothing sampled except the offset-0 time anchor.
     tracer, root, other = _ready_tracer(layer_rate=0.0)
@@ -299,6 +316,34 @@ def test_optimizer_step_recorded_every_sampled_step():
         BaseTracer.post_step_hook(tracer, opt, (), {})
         stages = {p.record.stage for p in tracer.pending}
         assert "post step" in stages
+
+
+def test_optimizer_post_uses_coordinate_captured_at_pre_hook(monkeypatch):
+    from probing.profiling import torch_probe as tp
+
+    tracer, _, _ = _ready_tracer()
+    optimizer = _FakeMod()
+    snapshot = object()
+    stamped_with = []
+    tracer._optimizer_step_snapshot = snapshot
+    tracer._open_spans[(id(optimizer), "step")] = (
+        None,
+        optimizer,
+        "pre step",
+        0.0,
+        0.0,
+    )
+    monkeypatch.setattr(tp, "mem_stats", lambda: tp.TorchTrace())
+    monkeypatch.setattr(
+        tracer,
+        "_stamp_step_role",
+        lambda record, snapshot=None: stamped_with.append(snapshot),
+    )
+    monkeypatch.setattr(tracer, "end_timing", lambda mod, stage: (0.0, None))
+
+    tracer._complete_post_stage(optimizer, "post step")
+
+    assert stamped_with == [snapshot]
 
 
 def test_sampled_step_defers_gpu_event_reads(monkeypatch):

--- a/tests/unit/probing/fakes/test_fakes.py
+++ b/tests/unit/probing/fakes/test_fakes.py
@@ -19,6 +19,8 @@ def _clean_fakes():
     megatron_ext._TRAINING_INIT = False
     megatron_ext._LAST_ROLE = None
     megatron_ext._LAST_ITERATION = None
+    megatron_ext._RECORDED_RANK_LAYOUTS.clear()
+    megatron_ext._CAPTURED_MODEL_IDS.clear()
     if fakes.is_installed():
         fakes.uninstall()
     try:
@@ -35,6 +37,8 @@ def _clean_fakes():
         fakes.uninstall()
     megatron_ext._PARALLEL_STATE_INIT = False
     megatron_ext._TRAINING_INIT = False
+    megatron_ext._RECORDED_RANK_LAYOUTS.clear()
+    megatron_ext._CAPTURED_MODEL_IDS.clear()
 
 
 def test_device_remap_cuda_to_meta():

--- a/web/assets/tailwind.css
+++ b/web/assets/tailwind.css
@@ -784,11 +784,6 @@ video {
   inset: 0px;
 }
 
-.inset-x-0 {
-  left: 0px;
-  right: 0px;
-}
-
 .inset-y-0 {
   top: 0px;
   bottom: 0px;
@@ -814,25 +809,12 @@ video {
   bottom: 5px;
 }
 
-.inset-y-\[7px\] {
-  top: 7px;
-  bottom: 7px;
-}
-
-.-right-3 {
-  right: -0.75rem;
-}
-
 .-top-px {
   top: -1px;
 }
 
 .bottom-0 {
   bottom: 0px;
-}
-
-.bottom-1\/2 {
-  bottom: 50%;
 }
 
 .bottom-3 {
@@ -857,6 +839,10 @@ video {
 
 .left-1\/4 {
   left: 25%;
+}
+
+.left-16 {
+  left: 4rem;
 }
 
 .left-2 {
@@ -919,34 +905,6 @@ video {
   top: 1.75rem;
 }
 
-.top-\[10px\] {
-  top: 10px;
-}
-
-.top-\[11px\] {
-  top: 11px;
-}
-
-.top-\[14px\] {
-  top: 14px;
-}
-
-.top-\[52px\] {
-  top: 52px;
-}
-
-.top-\[5px\] {
-  top: 5px;
-}
-
-.top-\[9px\] {
-  top: 9px;
-}
-
-.top-full {
-  top: 100%;
-}
-
 .z-10 {
   z-index: 10;
 }
@@ -977,10 +935,6 @@ video {
 
 .z-\[9996\] {
   z-index: 9996;
-}
-
-.z-\[9997\] {
-  z-index: 9997;
 }
 
 .z-\[9998\] {
@@ -1131,16 +1085,8 @@ video {
   display: grid;
 }
 
-.inline-grid {
-  display: inline-grid;
-}
-
 .hidden {
   display: none;
-}
-
-.h-0\.5 {
-  height: 0.125rem;
 }
 
 .h-1 {
@@ -1215,18 +1161,6 @@ video {
   height: 2.25rem;
 }
 
-.h-\[12px\] {
-  height: 12px;
-}
-
-.h-\[22px\] {
-  height: 22px;
-}
-
-.h-\[7px\] {
-  height: 7px;
-}
-
 .h-full {
   height: 100%;
 }
@@ -1253,10 +1187,6 @@ video {
 
 .max-h-64 {
   max-height: 16rem;
-}
-
-.max-h-72 {
-  max-height: 18rem;
 }
 
 .max-h-96 {
@@ -1297,6 +1227,10 @@ video {
 
 .min-h-0 {
   min-height: 0px;
+}
+
+.min-h-12 {
+  min-height: 3rem;
 }
 
 .min-h-14 {
@@ -1343,10 +1277,6 @@ video {
   width: 2.5rem;
 }
 
-.w-11 {
-  width: 2.75rem;
-}
-
 .w-12 {
   width: 3rem;
 }
@@ -1357,10 +1287,6 @@ video {
 
 .w-16 {
   width: 4rem;
-}
-
-.w-2 {
-  width: 0.5rem;
 }
 
 .w-2\.5 {
@@ -1411,10 +1337,6 @@ video {
   width: 2rem;
 }
 
-.w-80 {
-  width: 20rem;
-}
-
 .w-9 {
   width: 2.25rem;
 }
@@ -1453,6 +1375,10 @@ video {
 
 .min-w-2 {
   min-width: 0.5rem;
+}
+
+.min-w-64 {
+  min-width: 16rem;
 }
 
 .min-w-72 {
@@ -1620,10 +1546,6 @@ video {
   flex: 1 1 0%;
 }
 
-.flex-shrink-0 {
-  flex-shrink: 0;
-}
-
 .shrink-0 {
   flex-shrink: 0;
 }
@@ -1683,6 +1605,10 @@ video {
 
 .animate-spin {
   animation: spin 1s linear infinite;
+}
+
+.cursor-crosshair {
+  cursor: crosshair;
 }
 
 .cursor-not-allowed {
@@ -1757,6 +1683,10 @@ video {
 
 .grid-cols-\[minmax\(0\2c 1fr\)_auto_auto\] {
   grid-template-columns: minmax(0,1fr) auto auto;
+}
+
+.grid-cols-\[minmax\(16rem\2c 1fr\)_auto\] {
+  grid-template-columns: minmax(16rem,1fr) auto;
 }
 
 .grid-cols-\[minmax\(180px\2c 0\.7fr\)_minmax\(0\2c 1\.7fr\)_auto\] {
@@ -1852,6 +1782,11 @@ video {
 .gap-x-4 {
   -moz-column-gap: 1rem;
        column-gap: 1rem;
+}
+
+.gap-x-6 {
+  -moz-column-gap: 1.5rem;
+       column-gap: 1.5rem;
 }
 
 .gap-y-1 {
@@ -2152,6 +2087,11 @@ video {
   border-color: rgb(29 78 216 / var(--tw-border-opacity, 1));
 }
 
+.border-cyan-300 {
+  --tw-border-opacity: 1;
+  border-color: rgb(103 232 249 / var(--tw-border-opacity, 1));
+}
+
 .border-emerald-200 {
   --tw-border-opacity: 1;
   border-color: rgb(167 243 208 / var(--tw-border-opacity, 1));
@@ -2379,6 +2319,11 @@ video {
 .border-violet-200 {
   --tw-border-opacity: 1;
   border-color: rgb(221 214 254 / var(--tw-border-opacity, 1));
+}
+
+.border-violet-300 {
+  --tw-border-opacity: 1;
+  border-color: rgb(196 181 253 / var(--tw-border-opacity, 1));
 }
 
 .border-violet-500 {
@@ -3494,10 +3439,6 @@ video {
   background-color: rgb(252 211 77 / 0.8);
 }
 
-.bg-amber-400\/60 {
-  background-color: rgb(251 191 36 / 0.6);
-}
-
 .bg-amber-400\/\[0\.06\] {
   background-color: rgb(251 191 36 / 0.06);
 }
@@ -3618,6 +3559,11 @@ video {
   background-color: rgb(29 78 216 / var(--tw-bg-opacity, 1));
 }
 
+.bg-cyan-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(236 254 255 / var(--tw-bg-opacity, 1));
+}
+
 .bg-emerald-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(209 250 229 / var(--tw-bg-opacity, 1));
@@ -3674,10 +3620,6 @@ video {
 .bg-gray-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
-}
-
-.bg-gray-50\/30 {
-  background-color: rgb(249 250 251 / 0.3);
 }
 
 .bg-gray-50\/40 {
@@ -3906,6 +3848,11 @@ video {
 .bg-violet-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(237 233 254 / var(--tw-bg-opacity, 1));
+}
+
+.bg-violet-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(245 243 255 / var(--tw-bg-opacity, 1));
 }
 
 .bg-violet-50\/40 {
@@ -5009,10 +4956,6 @@ video {
   padding-left: 1.75rem;
 }
 
-.pr-1 {
-  padding-right: 0.25rem;
-}
-
 .pr-10 {
   padding-right: 2.5rem;
 }
@@ -5035,10 +4978,6 @@ video {
 
 .pt-3 {
   padding-top: 0.75rem;
-}
-
-.pt-4 {
-  padding-top: 1rem;
 }
 
 .pt-\[10vh\] {
@@ -5281,6 +5220,11 @@ video {
 .text-blue-950 {
   --tw-text-opacity: 1;
   color: rgb(23 37 84 / var(--tw-text-opacity, 1));
+}
+
+.text-cyan-800 {
+  --tw-text-opacity: 1;
+  color: rgb(21 94 117 / var(--tw-text-opacity, 1));
 }
 
 .text-emerald-200 {
@@ -5633,10 +5577,6 @@ video {
   outline-offset: 2px;
 }
 
-.outline {
-  outline-style: solid;
-}
-
 .ring {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
@@ -5915,11 +5855,6 @@ video {
   --tw-ring-color: rgb(91 33 182 / var(--tw-ring-opacity, 1));
 }
 
-.ring-white {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(255 255 255 / var(--tw-ring-opacity, 1));
-}
-
 .ring-white\/70 {
   --tw-ring-color: rgb(255 255 255 / 0.7);
 }
@@ -6068,6 +6003,16 @@ video {
   }
 }
 
+.placeholder\:text-gray-400::-moz-placeholder {
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity, 1));
+}
+
+.placeholder\:text-gray-400::placeholder {
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity, 1));
+}
+
 .placeholder\:text-slate-400::-moz-placeholder {
   --tw-text-opacity: 1;
   color: rgb(148 163 184 / var(--tw-text-opacity, 1));
@@ -6111,6 +6056,16 @@ video {
 .hover\:border-blue-400:hover {
   --tw-border-opacity: 1;
   border-color: rgb(96 165 250 / var(--tw-border-opacity, 1));
+}
+
+.hover\:border-blue-500:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(59 130 246 / var(--tw-border-opacity, 1));
+}
+
+.hover\:border-gray-300:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(209 213 219 / var(--tw-border-opacity, 1));
 }
 
 .hover\:border-slate-600:hover {
@@ -6183,10 +6138,6 @@ video {
 
 .hover\:bg-blue-600\/30:hover {
   background-color: rgb(37 99 235 / 0.3);
-}
-
-.hover\:bg-blue-600\/50:hover {
-  background-color: rgb(37 99 235 / 0.5);
 }
 
 .hover\:bg-blue-700:hover {
@@ -6730,10 +6681,6 @@ video {
   opacity: 1;
 }
 
-.hover\:opacity-90:hover {
-  opacity: 0.9;
-}
-
 .hover\:shadow-sm:hover {
   --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
@@ -7039,6 +6986,12 @@ video {
 .focus\:ring-0:focus {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\:ring-1:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
 }
 

--- a/web/src/next/pages/dashboard.rs
+++ b/web/src/next/pages/dashboard.rs
@@ -76,8 +76,17 @@ pub fn DashboardPage() -> Element {
     });
     let gpu = use_resource(move || {
         let request = gpu_request();
+        let available = capability_status(
+            "gpu",
+            "utilization",
+            &["device_id", "used_bytes", "total_bytes"],
+        );
         async move {
-            let snapshots = ApiClient::new().fetch_gpu_latest().await?;
+            let snapshots = if available.allows_query() {
+                ApiClient::new().fetch_gpu_latest().await?
+            } else {
+                Vec::new()
+            };
             let receipt = EvidenceReceipt::local("gpu.utilization", &request, snapshots.len());
             Ok(EvidencePayload::new(snapshots, receipt))
         }
@@ -108,6 +117,12 @@ pub fn DashboardPage() -> Element {
         "trace_event",
         &["record_type", "span_id", "name", "time"],
     );
+    let gpu_source = capability_status(
+        "gpu",
+        "utilization",
+        &["device_id", "used_bytes", "total_bytes"],
+    );
+    let gpu_reported = gpu_source != CapabilityStatus::Missing;
     let step_presentation = dashboard_step_presentation(step_source, step_state.as_ref());
     let bundle_request = step_request();
     let bundle_step_state = step_state.clone();
@@ -166,11 +181,11 @@ pub fn DashboardPage() -> Element {
             }
 
             EvidenceSurface {
-                div { class: if matches!(step_presentation, StepPresentation::Ready | StepPresentation::Loading) { "grid items-start xl:grid-cols-2" } else { "grid items-start" },
+                div { class: if gpu_reported && matches!(step_presentation, StepPresentation::Ready | StepPresentation::Loading) { "grid items-start xl:grid-cols-2" } else { "grid items-start" },
                     if step_presentation == StepPresentation::Ready {
                         EvidenceSection {
                         title: "Cluster step time".to_string(),
-                        subtitle: Some("Completed train.step samples aggregated across the returned ranks.".to_string()),
+                        subtitle: Some("Summary metrics use the latest completed step; the chart shows recent cluster history.".to_string()),
                         actions: rsx! {
                             ScopeBadge { label: step_scope.clone() }
                             if step_partial {
@@ -186,30 +201,38 @@ pub fn DashboardPage() -> Element {
                             LoadingPanel { label: "Loading training steps".to_string() }
                         }
                     }
-                    div { class: if matches!(step_presentation, StepPresentation::Ready | StepPresentation::Loading) { "border-t border-gray-200 xl:border-l xl:border-t-0" } else { "" },
-                        EvidenceSection {
-                            title: "Local GPU load".to_string(),
-                            subtitle: Some("Latest accelerator samples exposed by the current server process only.".to_string()),
-                            actions: rsx! {
-                                ScopeBadge { label: "Process-local".to_string() }
-                                EvidenceLink { route: NextRoute::Memory {}, label: "Open Memory →".to_string() }
-                            },
-                            match gpu_state.as_ref() {
-                                None => rsx! { LoadingPanel { label: "Loading GPU samples".to_string() } },
-                                Some(Err(error)) => rsx! { UnavailablePanel {
-                                    label: "GPU samples unavailable".to_string(),
-                                    detail: error.display_message(),
-                                }},
-                                Some(Ok(payload)) if payload.value.is_empty() => rsx! { UnavailablePanel {
-                                    label: "No GPU samples".to_string(),
-                                    detail: "The latest utilization query returned no devices.".to_string(),
-                                }},
-                                Some(Ok(payload)) => rsx! { GpuLoadPanel {
-                                    snapshots: payload.value.clone(),
-                                    health: gpu_health.clone().unwrap_or_default(),
-                                }},
+                    if gpu_reported {
+                        div { class: if matches!(step_presentation, StepPresentation::Ready | StepPresentation::Loading) { "border-t border-gray-200 xl:border-l xl:border-t-0" } else { "" },
+                            EvidenceSection {
+                                title: "Local GPU load".to_string(),
+                                subtitle: Some("Latest accelerator samples exposed by the current server process only.".to_string()),
+                                actions: rsx! {
+                                    ScopeBadge { label: "Process-local".to_string() }
+                                    EvidenceLink { route: NextRoute::Memory {}, label: "Open Memory →".to_string() }
+                                },
+                                match gpu_state.as_ref() {
+                                    None => rsx! { LoadingPanel { label: "Loading GPU samples".to_string() } },
+                                    Some(Err(error)) => rsx! { UnavailablePanel {
+                                        label: "GPU samples unavailable".to_string(),
+                                        detail: error.display_message(),
+                                    }},
+                                    Some(Ok(payload)) if payload.value.is_empty() => rsx! { UnavailablePanel {
+                                        label: "No GPU samples".to_string(),
+                                        detail: "The GPU collector is active but has not returned a device sample yet.".to_string(),
+                                    }},
+                                    Some(Ok(payload)) => rsx! { GpuLoadPanel {
+                                        snapshots: payload.value.clone(),
+                                        health: gpu_health.clone().unwrap_or_default(),
+                                    }},
+                                }
                             }
                         }
+                    }
+                }
+                if !gpu_reported {
+                    div { class: "flex flex-wrap items-center justify-between gap-2 border-t border-gray-200 px-4 py-2 text-xs text-gray-600",
+                        span { "Local GPU metrics are not enabled for this process." }
+                        EvidenceLink { route: NextRoute::Memory {}, label: "Open Memory →".to_string() }
                     }
                 }
                 if step_presentation == StepPresentation::Ready {
@@ -347,6 +370,7 @@ fn StepTimePanel(health: StepHealth) -> Element {
 
 #[component]
 pub(super) fn StepTrendChart(points: Vec<StepTrendPoint>) -> Element {
+    let mut hide_first = use_signal(|| false);
     if points.is_empty() {
         return rsx! {
             UnavailablePanel {
@@ -356,19 +380,19 @@ pub(super) fn StepTrendChart(points: Vec<StepTrendPoint>) -> Element {
         };
     }
 
-    let width = 720.0;
-    let height = 178.0;
-    let pad_left = 50.0;
-    let pad_right = 12.0;
-    let pad_top = 10.0;
-    let pad_bottom = 26.0;
-    let plot_width = width - pad_left - pad_right;
-    let plot_height = height - pad_top - pad_bottom;
-    let minimum = points
+    let can_hide_first = points.len() > 3;
+    let plotted = if can_hide_first && hide_first() {
+        points[1..].to_vec()
+    } else {
+        points
+    };
+    let width = 1000.0;
+    let height = 100.0;
+    let minimum = plotted
         .iter()
         .map(|point| point.median_ms)
         .fold(f64::INFINITY, f64::min);
-    let maximum = points
+    let maximum = plotted
         .iter()
         .map(|point| point.p95_ms)
         .fold(f64::NEG_INFINITY, f64::max);
@@ -378,14 +402,14 @@ pub(super) fn StepTrendChart(points: Vec<StepTrendPoint>) -> Element {
     let y_min = (minimum - padding).max(0.0);
     let y_max = maximum + padding;
     let y_span = (y_max - y_min).max(0.1);
-    let x_span = points.len().saturating_sub(1).max(1) as f64;
+    let point_count = plotted.len().max(1) as f64;
     let coordinates = |value: fn(&StepTrendPoint) -> f64| {
-        points
+        plotted
             .iter()
             .enumerate()
             .map(|(index, point)| {
-                let x = pad_left + index as f64 / x_span * plot_width;
-                let y = pad_top + (y_max - value(point)) / y_span * plot_height;
+                let x = (index as f64 + 0.5) / point_count * width;
+                let y = (y_max - value(point)) / y_span * height;
                 format!("{x:.1},{y:.1}")
             })
             .collect::<Vec<_>>()
@@ -393,8 +417,15 @@ pub(super) fn StepTrendChart(points: Vec<StepTrendPoint>) -> Element {
     };
     let median_line = coordinates(|point| point.median_ms);
     let p95_line = coordinates(|point| point.p95_ms);
-    let first_step = points.first().map(|point| point.step).unwrap_or_default();
-    let last_step = points.last().map(|point| point.step).unwrap_or_default();
+    let first_step = plotted.first().map(|point| point.step).unwrap_or_default();
+    let last_step = plotted.last().map(|point| point.step).unwrap_or_default();
+    let visible_ticks = step_tick_indices(plotted.len());
+    let step_ticks = plotted
+        .iter()
+        .enumerate()
+        .map(|(index, point)| visible_ticks.contains(&index).then_some(point.step))
+        .collect::<Vec<_>>();
+    let step_columns = step_ticks.len().max(1);
 
     rsx! {
         div {
@@ -402,62 +433,113 @@ pub(super) fn StepTrendChart(points: Vec<StepTrendPoint>) -> Element {
             role: "img",
             aria_label: "Recent step duration trend from step {first_step} to {last_step}; blue is median and violet is P95",
             div { class: "mb-1 flex items-center justify-between text-xs text-gray-500",
-                span { "Recent steps" }
+                div { class: "flex items-center gap-2",
+                    span { "Recent steps" }
+                    if can_hide_first {
+                        button {
+                            r#type: "button",
+                            class: "rounded border border-gray-200 px-1.5 py-0.5 font-medium text-gray-600 hover:border-gray-300 hover:bg-gray-50",
+                            aria_pressed: hide_first().to_string(),
+                            onclick: move |_| hide_first.toggle(),
+                            if hide_first() { "Show warmup" } else { "Hide warmup" }
+                        }
+                    }
+                }
                 div { class: "flex gap-3",
                     span { class: "flex items-center gap-1",
                         span { class: "inline-block h-px w-4 bg-blue-600" }
-                        "median"
+                        "Rank median"
                     }
                     span { class: "flex items-center gap-1",
                         span { class: "inline-block h-px w-4 bg-violet-500" }
-                        "P95"
+                        "Rank P95"
                     }
                 }
             }
-            svg {
-                class: "h-44 w-full",
-                view_box: "0 0 {width} {height}",
-                preserve_aspect_ratio: "none",
-                for tick in 0..=3 {
-                    {
-                        let ratio = tick as f64 / 3.0;
-                        let y = pad_top + ratio * plot_height;
-                        let value = y_max - ratio * y_span;
-                        rsx! {
-                            line {
-                                x1: "{pad_left}", y1: "{y}",
-                                x2: "{pad_left + plot_width}", y2: "{y}",
-                                stroke: "#e5e7eb", stroke_width: "1",
-                            }
-                            text {
-                                x: "{pad_left - 6.0}", y: "{y + 3.0}",
-                                text_anchor: "end", font_size: "11", fill: "#6b7280",
-                                "{format_duration(Some(value))}"
+            div { class: "relative h-44",
+                div { class: "absolute bottom-6 left-0 top-0 w-14",
+                    for tick in 0..=3 {
+                        {
+                            let ratio = tick as f64 / 3.0;
+                            let value = y_max - ratio * y_span;
+                            let position = if tick == 0 || tick == 3 {
+                                String::new()
+                            } else {
+                                format!("top: {:.2}%;", ratio * 100.0)
+                            };
+                            rsx! {
+                                span {
+                                    class: if tick == 0 {
+                                        "absolute left-0 top-0 w-14 whitespace-nowrap text-right text-xs text-gray-500"
+                                    } else if tick == 3 {
+                                        "absolute bottom-0 left-0 w-14 whitespace-nowrap text-right text-xs text-gray-500"
+                                    } else {
+                                        "absolute left-0 w-14 -translate-y-1/2 whitespace-nowrap text-right text-xs text-gray-500"
+                                    },
+                                    style: "{position}",
+                                    "{format_duration(Some(value))}"
+                                }
                             }
                         }
                     }
                 }
-                polyline {
-                    points: "{p95_line}", fill: "none", stroke: "#8b5cf6",
-                    stroke_width: "2", stroke_linejoin: "round", stroke_linecap: "round",
-                    vector_effect: "non-scaling-stroke",
+                div { class: "absolute bottom-6 left-16 right-3 top-0",
+                    svg {
+                        class: "h-full w-full",
+                        view_box: "0 0 {width} {height}",
+                        preserve_aspect_ratio: "none",
+                        for tick in 0..=3 {
+                            {
+                                let y = tick as f64 / 3.0 * height;
+                                rsx! {
+                                    line {
+                                        x1: "0", y1: "{y}",
+                                        x2: "{width}", y2: "{y}",
+                                        stroke: "#e5e7eb", stroke_width: "1",
+                                        vector_effect: "non-scaling-stroke",
+                                    }
+                                }
+                            }
+                        }
+                        polyline {
+                            points: "{p95_line}", fill: "none", stroke: "#8b5cf6",
+                            stroke_width: "4", stroke_opacity: "0.65",
+                            stroke_linejoin: "round", stroke_linecap: "round",
+                            vector_effect: "non-scaling-stroke",
+                        }
+                        polyline {
+                            points: "{median_line}", fill: "none", stroke: "#2563eb",
+                            stroke_width: "2", stroke_linejoin: "round", stroke_linecap: "round",
+                            vector_effect: "non-scaling-stroke",
+                        }
+                    }
                 }
-                polyline {
-                    points: "{median_line}", fill: "none", stroke: "#2563eb",
-                    stroke_width: "2.5", stroke_linejoin: "round", stroke_linecap: "round",
-                    vector_effect: "non-scaling-stroke",
-                }
-                text {
-                    x: "{pad_left}", y: "{height - 5.0}", text_anchor: "start",
-                    font_size: "11", fill: "#6b7280", "step {first_step}"
-                }
-                text {
-                    x: "{pad_left + plot_width}", y: "{height - 5.0}", text_anchor: "end",
-                    font_size: "11", fill: "#6b7280", "step {last_step}"
+                span { class: "absolute bottom-0 left-0 w-14 text-right text-xs text-gray-500", "Step" }
+                div {
+                    class: "absolute bottom-0 grid h-4 items-start",
+                    style: "left: 4rem; width: calc(100% - 4.75rem); grid-template-columns: repeat({step_columns}, minmax(0, 1fr));",
+                    for step in step_ticks {
+                        span {
+                            class: "min-w-0 truncate text-center font-mono text-xs text-gray-500",
+                            if let Some(step) = step {
+                                "{step}"
+                            }
+                        }
+                    }
                 }
             }
         }
     }
+}
+
+fn step_tick_indices(point_count: usize) -> Vec<usize> {
+    const MAX_TICKS: usize = 10;
+    if point_count <= MAX_TICKS {
+        return (0..point_count).collect();
+    }
+    let interval = point_count.div_ceil(MAX_TICKS);
+    let first = (point_count - 1) % interval;
+    (first..point_count).step_by(interval).collect()
 }
 
 #[component]
@@ -705,5 +787,20 @@ mod tests {
             dashboard_step_presentation(CapabilityStatus::Available, Some(&failed)),
             StepPresentation::Failed
         );
+    }
+
+    #[test]
+    fn step_ticks_adapt_integer_interval_to_total_steps() {
+        assert_eq!(step_tick_indices(4), vec![0, 1, 2, 3]);
+        assert_eq!(step_tick_indices(10), (0..10).collect::<Vec<_>>());
+        assert_eq!(
+            step_tick_indices(20),
+            vec![1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+        );
+        assert_eq!(
+            step_tick_indices(40),
+            vec![3, 7, 11, 15, 19, 23, 27, 31, 35, 39]
+        );
+        assert_eq!(step_tick_indices(21), vec![2, 5, 8, 11, 14, 17, 20]);
     }
 }

--- a/web/src/next/pages/memory.rs
+++ b/web/src/next/pages/memory.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use dioxus::prelude::*;
 use probing_proto::prelude::{DataFrame, Ele, Node};
@@ -80,24 +80,42 @@ pub fn MemoryPage() -> Element {
     });
     let devices = use_resource(move || {
         let request = evidence_request();
+        let available = capability_status(
+            "gpu",
+            "utilization",
+            &["device_id", "used_bytes", "total_bytes"],
+        );
         async move {
-            memory_query(
-                &device_summary_sql(request.window_us.unwrap_or_default()),
-                "gpu.utilization.latest",
-                &request,
-            )
-            .await
+            if available.allows_query() {
+                memory_query(
+                    &device_summary_sql(request.window_us.unwrap_or_default()),
+                    "gpu.utilization.latest",
+                    &request,
+                )
+                .await
+            } else {
+                Ok(empty_memory_query("gpu.utilization.latest", &request))
+            }
         }
     });
     let history = use_resource(move || {
         let request = evidence_request();
+        let available = capability_status(
+            "gpu",
+            "utilization",
+            &["device_id", "used_bytes", "total_bytes"],
+        );
         async move {
-            memory_query(
-                &device_history_sql(request.window_us.unwrap_or_default()),
-                "gpu.utilization.history",
-                &request,
-            )
-            .await
+            if available.allows_query() {
+                memory_query(
+                    &device_history_sql(request.window_us.unwrap_or_default()),
+                    "gpu.utilization.history",
+                    &request,
+                )
+                .await
+            } else {
+                Ok(empty_memory_query("gpu.utilization.history", &request))
+            }
         }
     });
     let allocator = use_resource(move || {
@@ -187,12 +205,24 @@ pub fn MemoryPage() -> Element {
         && matches!(device_state.as_ref(), Some(Ok(_)))
         && !device_rows.is_empty()
         && selected.is_none();
-    let scope = evidence_request().scope.label();
+    let current_request = evidence_request();
+    let scope = current_request.scope.label();
+    let known_ranks = node_rows
+        .iter()
+        .filter_map(|node| node.rank)
+        .collect::<BTreeSet<_>>()
+        .len();
     let allocator_source = capability_status(
         "python",
         "torch_trace",
         &["rank", "allocated", "max_allocated", "cached"],
     );
+    let device_source = capability_status(
+        "gpu",
+        "utilization",
+        &["device_id", "used_bytes", "total_bytes"],
+    );
+    let device_reported = device_source != CapabilityStatus::Missing;
 
     rsx! {
         WorkspacePage {
@@ -200,10 +230,30 @@ pub fn MemoryPage() -> Element {
             subtitle: "Physical device capacity, sampled usage, and framework allocator evidence for training and inference.".to_string(),
             actions: rsx! { span { class: "text-xs text-gray-500", "{scope} · {window_minutes}m window · {POLL_MS / 1000}s" } },
 
-            if allocator_source == CapabilityStatus::Missing {
+            if current_request.scope == EvidenceScope::LocalProcess && known_ranks > 1 {
+                InlineNotice {
+                    title: format!("Showing 1 of {known_ranks} ranks"),
+                    detail: "This page is scoped to the local process. Enable Cluster fan-out to compare memory across every reported rank.".to_string(),
+                    tone: NoticeTone::Info,
+                }
+            }
+
+            if allocator_source == CapabilityStatus::Missing && !device_reported {
+                InlineNotice {
+                    title: "Memory sources not reported".to_string(),
+                    detail: "Neither physical-device sampling nor PyTorch allocator evidence is enabled for this process.".to_string(),
+                    tone: NoticeTone::Info,
+                }
+            } else if allocator_source == CapabilityStatus::Missing {
                 InlineNotice {
                     title: "Allocator source not reported".to_string(),
                     detail: "Physical device memory remains available; PyTorch allocator and module-delta sections are hidden.".to_string(),
+                    tone: NoticeTone::Info,
+                }
+            } else if !device_reported {
+                InlineNotice {
+                    title: "Device memory source not reported".to_string(),
+                    detail: "The GPU collector is not enabled for this process; PyTorch allocator evidence remains available.".to_string(),
                     tone: NoticeTone::Info,
                 }
             }
@@ -223,7 +273,7 @@ pub fn MemoryPage() -> Element {
                 EvidenceSection {
                     title: "Device memory".to_string(),
                     subtitle: Some("Current usage is the latest reported sample; peak is the highest sample inside the selected window.".to_string()),
-                    DeviceOverview { state: device_state.clone(), devices: device_rows.clone() }
+                    DeviceOverview { state: device_state.clone(), devices: device_rows.clone(), source_reported: device_reported }
                 }
                 EvidenceSection {
                     title: "Memory timeline".to_string(),
@@ -233,6 +283,7 @@ pub fn MemoryPage() -> Element {
                         state: history_state,
                         selected: selected.clone(),
                         window_minutes,
+                        source_reported: device_reported,
                         mismatch_detail: selection_mismatch.then(|| format!(
                             "{} has no sample in the {scope} result.",
                             memory_context_label(&context),
@@ -308,7 +359,11 @@ fn push_memory_query(
 }
 
 #[component]
-fn DeviceOverview(state: Option<Result<MemoryQuery>>, devices: Vec<DeviceMemory>) -> Element {
+fn DeviceOverview(
+    state: Option<Result<MemoryQuery>>,
+    devices: Vec<DeviceMemory>,
+    source_reported: bool,
+) -> Element {
     match state {
         None => rsx! { LoadingPanel { label: "Loading device memory".to_string() } },
         Some(Err(error)) => rsx! { UnavailablePanel {
@@ -316,8 +371,12 @@ fn DeviceOverview(state: Option<Result<MemoryQuery>>, devices: Vec<DeviceMemory>
             detail: error.display_message(),
         }},
         Some(Ok(_)) if devices.is_empty() => rsx! { UnavailablePanel {
-            label: "No device memory samples".to_string(),
-            detail: "gpu.utilization returned no samples in the selected scope and window.".to_string(),
+            label: if source_reported { "No device memory samples".to_string() } else { "Device memory not reported".to_string() },
+            detail: if source_reported {
+                "The GPU collector returned no samples in the selected scope and window.".to_string()
+            } else {
+                "Enable the GPU collector to record physical-device memory usage.".to_string()
+            },
         }},
         Some(Ok(query)) => {
             let current = devices.iter().map(|row| row.current_bytes).sum::<u64>();
@@ -404,12 +463,23 @@ fn MemoryTimeline(
     state: Option<Result<MemoryQuery>>,
     selected: Option<DeviceMemory>,
     window_minutes: usize,
+    source_reported: bool,
     mismatch_detail: Option<String>,
 ) -> Element {
     let Some(selected) = selected else {
         return rsx! { UnavailablePanel {
-            label: if mismatch_detail.is_some() { "No matching device sample".to_string() } else { "Select a device".to_string() },
-            detail: mismatch_detail.unwrap_or_else(|| "Choose a device in the physical map to inspect its sampled timeline.".to_string()),
+            label: if !source_reported {
+                "Memory timeline not reported".to_string()
+            } else if mismatch_detail.is_some() {
+                "No matching device sample".to_string()
+            } else {
+                "Select a device".to_string()
+            },
+            detail: if !source_reported {
+                "The GPU collector is not enabled, so no physical-device timeline is available.".to_string()
+            } else {
+                mismatch_detail.unwrap_or_else(|| "Choose a device in the physical map to inspect its sampled timeline.".to_string())
+            },
         }};
     };
     match state {
@@ -439,26 +509,50 @@ fn MemoryTimeline(
 
 #[component]
 fn MemoryLineChart(points: Vec<MemoryPoint>, selected: DeviceMemory) -> Element {
+    let mut fit_data = use_signal(|| true);
     let width = 900.0;
-    let height = 180.0;
-    let left = 58.0;
-    let top = 10.0;
-    let plot_width = width - left - 10.0;
-    let plot_height = height - top - 24.0;
+    let height = 146.0;
     let total = points
         .iter()
         .map(|point| point.total_bytes)
         .max()
         .unwrap_or(1)
         .max(1);
+    let observed_min = points
+        .iter()
+        .map(|point| point.used_bytes)
+        .min()
+        .unwrap_or_default();
+    let observed_max = points
+        .iter()
+        .map(|point| point.used_bytes)
+        .max()
+        .unwrap_or(total);
+    let observed_span = observed_max.saturating_sub(observed_min);
+    let fit_padding = observed_span
+        .saturating_div(8)
+        .max(observed_max.saturating_div(50))
+        .max(256 * 1024 * 1024);
+    let y_min = if fit_data() {
+        observed_min.saturating_sub(fit_padding)
+    } else {
+        0
+    };
+    let y_max = if fit_data() {
+        observed_max.saturating_add(fit_padding).min(total)
+    } else {
+        total
+    };
+    let y_span = y_max.saturating_sub(y_min).max(1);
     let start = points.first().map(|point| point.ts).unwrap_or_default();
     let end = points.last().map(|point| point.ts).unwrap_or(start);
     let time_span = (end - start).max(1) as f64;
     let line = points
         .iter()
         .map(|point| {
-            let x = left + (point.ts - start) as f64 / time_span * plot_width;
-            let y = top + (1.0 - point.used_bytes as f64 / total as f64) * plot_height;
+            let x = (point.ts - start) as f64 / time_span * width;
+            let relative = point.used_bytes.saturating_sub(y_min) as f64 / y_span as f64;
+            let y = (1.0 - relative) * height;
             format!("{x:.1},{y:.1}")
         })
         .collect::<Vec<_>>()
@@ -467,30 +561,150 @@ fn MemoryLineChart(points: Vec<MemoryPoint>, selected: DeviceMemory) -> Element 
         .rank
         .map(|rank| format!("rank {rank} · "))
         .unwrap_or_default();
+    let history_span = format_history_span(end.saturating_sub(start).max(0) as u64);
+    let start_time = format_sample_time(start);
+    let end_time = format_sample_time(end);
+    let sample_age_us = unix_time_micros().saturating_sub(end.max(0) as u64);
+    let sample_age = format_sample_age(sample_age_us);
+    let sample_is_stale = sample_age_us > 15_000_000;
     rsx! {
-        div { role: "img", aria_label: "{rank}GPU {selected.device_id} memory used over time",
-            div { class: "mb-2 flex flex-wrap items-center justify-between gap-2 text-xs text-gray-600",
-                span { class: "font-medium text-gray-900", "{selected.host} · {rank}GPU {selected.device_id}" }
-                span { "latest {format_bytes(selected.current_bytes)} · sampled peak {format_bytes(selected.peak_bytes)} · capacity {format_bytes(selected.total_bytes)}" }
+        div {
+            div { class: "mb-3 flex flex-wrap items-start justify-between gap-x-6 gap-y-1 text-xs",
+                div { class: "min-w-0",
+                    div { class: "font-semibold text-gray-900", "{rank}GPU {selected.device_id}" }
+                    div { class: "max-w-xl truncate text-gray-500", title: "{selected.host}", "{selected.host}" }
+                }
+                div { class: "flex flex-wrap items-center gap-x-4 gap-y-1 text-gray-600",
+                    span {
+                        class: if sample_is_stale {
+                            "rounded bg-amber-50 px-1.5 py-0.5 font-medium text-amber-800"
+                        } else {
+                            "rounded bg-emerald-50 px-1.5 py-0.5 font-medium text-emerald-700"
+                        },
+                        if sample_is_stale { "Stale · {sample_age}" } else { "Live · {sample_age}" }
+                    }
+                    span { "Latest " strong { class: "font-semibold text-gray-900", "{format_bytes(selected.current_bytes)}" } }
+                    span { "Peak " strong { class: "font-semibold text-gray-900", "{format_bytes(selected.peak_bytes)}" } }
+                    span { "Capacity " strong { class: "font-semibold text-gray-900", "{format_bytes(selected.total_bytes)}" } }
+                    button {
+                        r#type: "button",
+                        class: "rounded border border-gray-200 bg-white px-2 py-1 font-medium text-gray-600 hover:border-gray-300 hover:bg-gray-50",
+                        aria_pressed: fit_data().to_string(),
+                        onclick: move |_| fit_data.toggle(),
+                        if fit_data() { "Full capacity" } else { "Fit data" }
+                    }
+                }
             }
-            svg { class: "h-44 w-full", view_box: "0 0 {width} {height}", preserve_aspect_ratio: "none",
-                for tick in 0..=4 {
-                    {
-                        let ratio = tick as f64 / 4.0;
-                        let y = top + ratio * plot_height;
-                        let value = ((1.0 - ratio) * total as f64) as u64;
-                        rsx! {
-                            line { x1: "{left}", y1: "{y}", x2: "{left + plot_width}", y2: "{y}", stroke: "#e5e7eb", stroke_width: "1" }
-                            text { x: "{left - 6.0}", y: "{y + 3.0}", text_anchor: "end", font_size: "11", fill: "#6b7280", "{format_bytes(value)}" }
+            div {
+                class: "relative h-44",
+                role: "img",
+                aria_label: "{rank}GPU {selected.device_id} memory used over time; vertical scale from {format_bytes(y_min)} to {format_bytes(y_max)}",
+                div { class: "absolute bottom-6 left-0 top-0 w-14",
+                    for tick in 0..=4 {
+                        {
+                            let ratio = tick as f64 / 4.0;
+                            let value = y_max.saturating_sub((ratio * y_span as f64) as u64);
+                            let position = if tick == 0 || tick == 4 {
+                                String::new()
+                            } else {
+                                format!("top: {:.2}%;", ratio * 100.0)
+                            };
+                            rsx! {
+                                span {
+                                    class: if tick == 0 {
+                                        "absolute left-0 top-0 w-14 whitespace-nowrap text-right text-xs text-gray-500"
+                                    } else if tick == 4 {
+                                        "absolute bottom-0 left-0 w-14 whitespace-nowrap text-right text-xs text-gray-500"
+                                    } else {
+                                        "absolute left-0 w-14 -translate-y-1/2 whitespace-nowrap text-right text-xs text-gray-500"
+                                    },
+                                    style: "{position}",
+                                    "{format_bytes(value)}"
+                                }
+                            }
                         }
                     }
                 }
-                polyline { points: "{line}", fill: "none", stroke: "#7c3aed", stroke_width: "2.5", stroke_linejoin: "round", stroke_linecap: "round", vector_effect: "non-scaling-stroke" }
-                text { x: "{left}", y: "{height - 4.0}", font_size: "11", fill: "#6b7280", "oldest" }
-                text { x: "{left + plot_width}", y: "{height - 4.0}", text_anchor: "end", font_size: "11", fill: "#6b7280", "latest" }
+                div { class: "absolute bottom-6 left-16 right-3 top-0",
+                    svg { class: "h-full w-full", view_box: "0 0 {width} {height}", preserve_aspect_ratio: "none",
+                        for tick in 0..=4 {
+                            {
+                                let y = tick as f64 / 4.0 * height;
+                                rsx! {
+                                    line { x1: "0", y1: "{y}", x2: "{width}", y2: "{y}", stroke: "#e5e7eb", stroke_width: "1", vector_effect: "non-scaling-stroke" }
+                                }
+                            }
+                        }
+                        polyline { points: "{line}", fill: "none", stroke: "#7c3aed", stroke_width: "2.5", stroke_linejoin: "round", stroke_linecap: "round", vector_effect: "non-scaling-stroke" }
+                        for point in points.iter() {
+                            {
+                                let x = (point.ts - start) as f64 / time_span * width;
+                                let relative = point.used_bytes.saturating_sub(y_min) as f64 / y_span as f64;
+                                let y = (1.0 - relative) * height;
+                                let time = format_sample_time(point.ts);
+                                let used = format_bytes(point.used_bytes);
+                                rsx! {
+                                    circle {
+                                        cx: "{x}", cy: "{y}", r: "5",
+                                        fill: "transparent", stroke: "transparent",
+                                        class: "cursor-crosshair",
+                                        title { "{time} · {used}" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                span { class: "absolute bottom-0 left-16 text-xs text-gray-500", "{start_time} · -{history_span}" }
+                span { class: "absolute bottom-0 right-3 text-xs text-gray-500", "{end_time} · Latest" }
             }
         }
     }
+}
+
+fn format_history_span(duration_us: u64) -> String {
+    let seconds = duration_us / 1_000_000;
+    if seconds >= 3600 {
+        format!("{:.1}h", seconds as f64 / 3600.0)
+    } else if seconds >= 60 {
+        format!("{:.1}m", seconds as f64 / 60.0)
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+fn format_sample_age(age_us: u64) -> String {
+    let seconds = age_us / 1_000_000;
+    if seconds < 2 {
+        "now".to_string()
+    } else if seconds < 60 {
+        format!("{seconds}s ago")
+    } else {
+        format!("{:.1}m ago", seconds as f64 / 60.0)
+    }
+}
+
+fn format_sample_time(timestamp_us: i64) -> String {
+    chrono::DateTime::from_timestamp_micros(timestamp_us)
+        .map(|timestamp| timestamp.format("%H:%M:%S UTC").to_string())
+        .unwrap_or_else(|| "unknown time".to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn unix_time_micros() -> u64 {
+    (js_sys::Date::now() * 1_000.0).max(0.0) as u64
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn unix_time_micros() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_micros()
+        .try_into()
+        .unwrap_or(u64::MAX)
 }
 
 #[component]
@@ -796,6 +1010,11 @@ mod tests {
         assert_eq!(format_bytes(8 << 30), "8.0 GiB");
         assert_eq!(format_ratio(3, 4), "75.0%");
         assert_eq!(format_ratio(1, 0), "—");
+        assert_eq!(format_history_span(45_000_000), "45s");
+        assert_eq!(format_history_span(300_000_000), "5.0m");
+        assert_eq!(format_sample_age(1_000_000), "now");
+        assert_eq!(format_sample_age(12_000_000), "12s ago");
+        assert_eq!(format_sample_time(0), "00:00:00 UTC");
     }
 
     #[test]

--- a/web/src/next/pages/training.rs
+++ b/web/src/next/pages/training.rs
@@ -70,6 +70,16 @@ const DEVICE_MEMORY_SQL: &str = "WITH samples AS ( \
          AND (local_rank < 0 OR device_id = local_rank) \
        ORDER BY device_id LIMIT 16";
 
+// Keep these dynamic Python tables behind a CTE so cluster fan-out uses the
+// current heartbeat registry rather than a startup-time global-catalog snapshot.
+const MEGATRON_RANK_LAYOUT_SQL: &str = "WITH layout AS ( \
+     SELECT * FROM python.megatron_rank_layout \
+     ) SELECT recorded_at_ns, rank, role, \
+     tp_rank, tp_size, pp_rank, pp_size, dp_rank, dp_size, cp_rank, cp_size, \
+     ep_rank, ep_size, vp_rank, vp_size, model_chunk, layer_start, layer_end, \
+     module_count, layout_key FROM layout \
+     ORDER BY recorded_at_ns DESC, rank, model_chunk LIMIT 512";
+
 #[component]
 pub fn TrainingPage() -> Element {
     let visible = use_page_visible();
@@ -188,7 +198,73 @@ pub fn TrainingPage() -> Element {
     });
     let device_memory = use_resource(move || {
         let request = evidence_request();
-        async move { training_query("gpu.utilization memory", DEVICE_MEMORY_SQL, &request).await }
+        let available = capability_status(
+            "gpu",
+            "utilization",
+            &["device_id", "used_bytes", "total_bytes"],
+        );
+        async move {
+            if available.allows_query() {
+                training_query("gpu.utilization memory", DEVICE_MEMORY_SQL, &request).await
+            } else {
+                Ok(empty_dataframe_payload("gpu.utilization memory", &request))
+            }
+        }
+    });
+    let megatron_rank_layout = use_resource(move || {
+        let request = evidence_request().for_scope(EvidenceScope::ClusterFanout, None);
+        let available = capability_status(
+            "python",
+            "megatron_rank_layout",
+            &["rank", "tp_rank", "pp_rank", "dp_rank"],
+        );
+        async move {
+            if available.allows_query() {
+                training_query(
+                    "python.megatron_rank_layout",
+                    MEGATRON_RANK_LAYOUT_SQL,
+                    &request,
+                )
+                .await
+            } else {
+                Ok(empty_dataframe_payload(
+                    "python.megatron_rank_layout",
+                    &request,
+                ))
+            }
+        }
+    });
+    let megatron_module_catalog = use_resource(move || {
+        let request = evidence_request().for_scope(EvidenceScope::ClusterFanout, None);
+        let rank = request.context.rank;
+        let available = capability_status(
+            "python",
+            "megatron_module_catalog",
+            &["rank", "module_path", "module_type"],
+        );
+        async move {
+            let Some(rank) = rank.filter(|rank| *rank >= 0) else {
+                return Ok(empty_dataframe_payload(
+                    "python.megatron_module_catalog",
+                    &request,
+                ));
+            };
+            if !available.allows_query() {
+                return Ok(empty_dataframe_payload(
+                    "python.megatron_module_catalog",
+                    &request,
+                ));
+            }
+            let sql = format!(
+                "WITH catalog AS (SELECT * FROM python.megatron_module_catalog) \
+                 SELECT rank, layout_key, model_chunk, module_path, parent_path, \
+                 module_type, depth, local_layer_index, global_layer_index, \
+                 parameter_count, trainable_parameter_count, dtype, device, is_leaf \
+                 FROM catalog WHERE rank = {rank} \
+                 ORDER BY model_chunk, module_path LIMIT 2048"
+            );
+            training_query("python.megatron_module_catalog", &sql, &request).await
+        }
     });
 
     let step_state = steps.read().clone();
@@ -198,6 +274,8 @@ pub fn TrainingPage() -> Element {
     let group_communication_state = group_communication.read().clone();
     let rank_memory_state = rank_memory.read().clone();
     let device_memory_state = device_memory.read().clone();
+    let megatron_rank_layout_state = megatron_rank_layout.read().clone();
+    let megatron_module_catalog_state = megatron_module_catalog.read().clone();
     let step_health = step_state
         .as_ref()
         .and_then(|result| result.as_ref().ok())
@@ -238,6 +316,8 @@ pub fn TrainingPage() -> Element {
     let group_view_state = payload_value_state(&group_communication_state);
     let rank_memory_view_state = payload_value_state(&rank_memory_state);
     let device_memory_view_state = payload_value_state(&device_memory_state);
+    let megatron_rank_layout_view_state = payload_value_state(&megatron_rank_layout_state);
+    let megatron_module_catalog_view_state = payload_value_state(&megatron_module_catalog_state);
     let placement_partial_sources = [
         partial_source("communication groups", &group_communication_state),
         partial_source("allocator", &rank_memory_state),
@@ -247,7 +327,19 @@ pub fn TrainingPage() -> Element {
     .flatten()
     .collect::<Vec<_>>();
     let placement_partial_label = placement_partial_sources.join(" · ");
-    let scope = evidence_request().scope.label();
+    let current_request = evidence_request();
+    let scope = current_request.scope.label();
+    let known_ranks = node_state
+        .as_ref()
+        .and_then(|state| state.as_ref().ok())
+        .map(|payload| {
+            payload
+                .value
+                .iter()
+                .filter(|node| node.rank.is_some())
+                .count()
+        })
+        .unwrap_or_default();
     let step_source = capability_status(
         "python",
         "trace_event",
@@ -280,6 +372,14 @@ pub fn TrainingPage() -> Element {
             subtitle: "Step timing, physical rank placement, module hooks, and collective measurements.".to_string(),
             actions: rsx! { span { class: "text-xs text-gray-500", "{scope} · {POLL_MS / 1000}s" } },
 
+            if current_request.scope == EvidenceScope::LocalProcess && known_ranks > 1 {
+                InlineNotice {
+                    title: format!("Local metrics with {known_ranks} reported ranks"),
+                    detail: "Step, module, and allocator sections are scoped to this process. Placement and Megatron topology remain cluster-wide; enable Cluster fan-out for cross-rank metrics.".to_string(),
+                    tone: NoticeTone::Info,
+                }
+            }
+
             if !missing_sources.is_empty() {
                 InlineNotice {
                     title: "Sources not reported".to_string(),
@@ -302,7 +402,7 @@ pub fn TrainingPage() -> Element {
                     if !payload.value.is_empty() {
                         EvidenceSection {
                             title: "Placement".to_string(),
-                            subtitle: Some("One square per reported accelerator process; selecting a rank links its node, step, and exact communication-group evidence.".to_string()),
+                            subtitle: Some("One square per reported accelerator process. Megatron topology and selected-rank modules are always gathered cluster-wide.".to_string()),
                             divided: true,
                             if !placement_partial_sources.is_empty() {
                                 div { class: "border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900",
@@ -316,6 +416,8 @@ pub fn TrainingPage() -> Element {
                                 group_communication: group_view_state.clone(),
                                 rank_memory: rank_memory_view_state.clone(),
                                 device_memory: device_memory_view_state.clone(),
+                                megatron_rank_layout: megatron_rank_layout_view_state.clone(),
+                                megatron_module_catalog: megatron_module_catalog_view_state.clone(),
                             }
                         }
                     }
@@ -582,6 +684,7 @@ mod tests {
         assert!(DEVICE_MEMORY_SQL.contains("LIMIT 16"));
         assert!(DEVICE_MEMORY_SQL.contains("process.envs WHERE name = 'RANK'"));
         assert!(DEVICE_MEMORY_SQL.contains("process.envs WHERE name = 'LOCAL_RANK'"));
+        assert!(MEGATRON_RANK_LAYOUT_SQL.contains("python.megatron_rank_layout"));
     }
 
     #[test]

--- a/web/src/next/pages/training_placement.rs
+++ b/web/src/next/pages/training_placement.rs
@@ -21,6 +21,7 @@ struct PlacementProcess {
     coordinates: Vec<(String, String)>,
     status: Option<String>,
     timestamp: u64,
+    layout: Option<RankLayoutSummary>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -121,6 +122,29 @@ enum DeviceMemoryEvidence {
     Loaded(Vec<DeviceMemorySample>),
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct RankLayoutSummary {
+    layer_start: Option<i32>,
+    layer_end: Option<i32>,
+    module_count: usize,
+    model_chunks: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ModuleCatalogEntry {
+    model_chunk: i32,
+    module_path: String,
+    module_type: String,
+    depth: usize,
+    local_layer_index: Option<i32>,
+    global_layer_index: Option<i32>,
+    parameter_count: u64,
+    trainable_parameter_count: u64,
+    dtype: String,
+    device: String,
+    is_leaf: bool,
+}
+
 #[component]
 pub(super) fn TrainingPlacement(
     nodes: Vec<Node>,
@@ -129,9 +153,22 @@ pub(super) fn TrainingPlacement(
     group_communication: Option<Result<DataFrame>>,
     rank_memory: Option<Result<DataFrame>>,
     device_memory: Option<Result<DataFrame>>,
+    megatron_rank_layout: Option<Result<DataFrame>>,
+    megatron_module_catalog: Option<Result<DataFrame>>,
 ) -> Element {
-    let placement = build_placement(&nodes);
-    rsx! { PlacementDiagram { placement, local_step, step_health, group_communication, rank_memory, device_memory } }
+    let layouts = rank_layout_evidence(megatron_rank_layout.as_ref());
+    let placement = build_placement(&nodes, &layouts);
+    rsx! {
+        PlacementDiagram {
+            placement,
+            local_step,
+            step_health,
+            group_communication,
+            rank_memory,
+            device_memory,
+            megatron_module_catalog,
+        }
+    }
 }
 
 #[component]
@@ -142,6 +179,7 @@ fn PlacementDiagram(
     group_communication: Option<Result<DataFrame>>,
     rank_memory: Option<Result<DataFrame>>,
     device_memory: Option<Result<DataFrame>>,
+    megatron_module_catalog: Option<Result<DataFrame>>,
 ) -> Element {
     let missing_ranks = placement
         .expected_ranks
@@ -166,7 +204,148 @@ fn PlacementDiagram(
                     }
                 }
             }
-            PlacementOverview { placement, local_step, step_health, group_communication, rank_memory, device_memory }
+            LogicalTopology { placement: placement.clone(), local_step }
+            PlacementOverview { placement, local_step, step_health, group_communication, rank_memory, device_memory, megatron_module_catalog }
+        }
+    }
+}
+
+#[component]
+fn LogicalTopology(placement: PlacementModel, local_step: Option<i64>) -> Element {
+    let mut selected_dp = use_signal(|| 0);
+    let processes = placement
+        .hosts
+        .iter()
+        .flat_map(|host| host.processes.iter())
+        .cloned()
+        .collect::<Vec<_>>();
+    let dp_values = processes
+        .iter()
+        .filter_map(|process| coordinate_i32(process, "dp"))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if dp_values.is_empty()
+        || !processes.iter().any(|process| {
+            coordinate(process, "pp").is_some() && coordinate(process, "tp").is_some()
+        })
+    {
+        return rsx! {};
+    }
+    let pinned_dp = INVESTIGATION_CONTEXT
+        .read()
+        .rank
+        .and_then(|rank| processes.iter().find(|process| process.rank == Some(rank)))
+        .and_then(|process| coordinate_i32(process, "dp"));
+    let default_dp = pinned_dp.unwrap_or(dp_values[0]);
+    let requested_dp = selected_dp();
+    let selected = if dp_values.contains(&requested_dp) {
+        requested_dp
+    } else {
+        default_dp
+    };
+    let pp_values = processes
+        .iter()
+        .filter(|process| coordinate_i32(process, "dp") == Some(selected))
+        .filter_map(|process| coordinate_i32(process, "pp"))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let tp_values = processes
+        .iter()
+        .filter(|process| coordinate_i32(process, "dp") == Some(selected))
+        .filter_map(|process| coordinate_i32(process, "tp"))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let pp_count = pp_values.len();
+    let mut cells = Vec::new();
+    for tp in &tp_values {
+        for pp in &pp_values {
+            let matching = processes
+                .iter()
+                .filter(|process| {
+                    coordinate_i32(process, "dp") == Some(selected)
+                        && coordinate_i32(process, "tp") == Some(*tp)
+                        && coordinate_i32(process, "pp") == Some(*pp)
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            cells.push((*tp, *pp, matching));
+        }
+    }
+
+    rsx! {
+        div { class: "rounded-md border border-gray-200 bg-white p-3",
+            div { class: "mb-3 flex flex-wrap items-center justify-between gap-2",
+                div {
+                    div { class: "text-xs font-semibold uppercase tracking-wide text-gray-600", "Logical model placement" }
+                    div { class: "mt-0.5 text-xs text-gray-500", "Pipeline stages by tensor-parallel lane; choose a data-parallel replica." }
+                }
+                div { class: "flex flex-wrap items-center gap-1",
+                    for dp in dp_values {
+                        button {
+                            r#type: "button",
+                            class: if dp == selected { "rounded border border-blue-600 bg-blue-600 px-2 py-1 font-mono text-xs font-semibold text-white" } else { "rounded border border-gray-300 bg-white px-2 py-1 font-mono text-xs text-gray-700 hover:border-blue-400" },
+                            onclick: move |_| selected_dp.set(dp),
+                            "DP{dp}"
+                        }
+                    }
+                }
+            }
+            div { class: "overflow-x-auto",
+                div {
+                    class: "grid min-w-max gap-1.5",
+                    style: "grid-template-columns: 3rem repeat({pp_count}, minmax(7.5rem, 1fr));",
+                    span {}
+                    for pp in &pp_values {
+                        div { class: "rounded bg-amber-50 px-2 py-1 text-center font-mono text-xs font-semibold text-amber-900", "PP{pp}" }
+                    }
+                    for tp in &tp_values {
+                        div { class: "flex items-center justify-center rounded bg-violet-50 px-2 font-mono text-xs font-semibold text-violet-900", "TP{tp}" }
+                        for (_, pp, processes) in cells.iter().filter(|(cell_tp, _, _)| cell_tp == tp) {
+                            if !processes.is_empty() {
+                                div { class: "grid gap-1 rounded border border-gray-200 bg-white p-1",
+                                    for process in processes {
+                                        LogicalRankCell { process: process.clone(), pp: *pp, local_step }
+                                    }
+                                }
+                            } else {
+                                div { class: "flex min-h-12 items-center justify-center rounded border border-dashed border-gray-200 text-xs text-gray-400", "missing" }
+                            }
+                        }
+                    }
+                }
+            }
+            div { class: "mt-2 text-xs text-gray-500", "Click a rank to inspect its static module tree." }
+        }
+    }
+}
+
+#[component]
+fn LogicalRankCell(process: PlacementProcess, pp: i32, local_step: Option<i64>) -> Element {
+    let rank = process.rank;
+    let rank_label = rank
+        .map(|rank| format!("R{rank}"))
+        .unwrap_or_else(|| "R?".to_string());
+    let layer_label = process
+        .layout
+        .as_ref()
+        .map(format_rank_layout)
+        .unwrap_or_else(|| "layers not reported".to_string());
+    let title = format!("{rank_label} · PP{pp} · {layer_label}");
+    rsx! {
+        button {
+            r#type: "button",
+            class: "min-h-12 rounded border border-gray-300 bg-gray-50 px-2 py-1 text-left hover:border-blue-500 hover:bg-blue-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-700",
+            title: "{title}",
+            onclick: move |_| {
+                if let Some(rank) = rank {
+                    set_training_rank_context(rank, local_step, None);
+                }
+            },
+            div { class: "font-mono text-xs font-semibold text-gray-950", "{rank_label}" }
+            div { class: "mt-0.5 truncate font-mono text-xs text-gray-600", "{layer_label}" }
         }
     }
 }
@@ -179,6 +358,7 @@ fn PlacementOverview(
     group_communication: Option<Result<DataFrame>>,
     rank_memory: Option<Result<DataFrame>>,
     device_memory: Option<Result<DataFrame>>,
+    megatron_module_catalog: Option<Result<DataFrame>>,
 ) -> Element {
     let mut hovered_rank = use_signal(|| None::<i32>);
     let mut tooltip_rank = use_signal(|| None::<i32>);
@@ -205,7 +385,6 @@ fn PlacementOverview(
         &placement_memory,
         DeviceMemoryEvidence::Loaded(samples) if !samples.is_empty()
     );
-    let host_columns = placement.hosts.len().clamp(1, 8);
     let tooltip_selection = tooltip_rank().and_then(|rank| {
         placement.hosts.iter().find_map(|host| {
             host.processes
@@ -241,14 +420,15 @@ fn PlacementOverview(
             div { class: "min-w-0",
                 div { class: "overflow-x-auto pb-0.5",
                     div {
-                        class: "inline-grid gap-1.5",
-                        style: "grid-template-columns: repeat({host_columns}, 3rem);",
+                        class: "flex min-w-max flex-wrap gap-1.5",
                         for (host_index, host) in placement.hosts.iter().enumerate() {
                             div {
                                 class: "min-w-0 rounded border border-gray-200 bg-white p-1",
                                 aria_label: "Host {host_index}: {host.name}",
                                 div { class: "mb-1 truncate text-center font-mono text-xs text-gray-600", "H{host_index}" }
-                                div { class: "grid grid-cols-1 justify-items-center gap-0.5",
+                                div {
+                                    class: "grid justify-items-center gap-0.5",
+                                    style: "grid-template-columns: repeat({host.processes.len().clamp(1, 8)}, 1.5rem);",
                                     for process in host.processes.iter() {
                                         PlacementCell {
                                             host: host.name.clone(),
@@ -306,6 +486,7 @@ fn PlacementOverview(
                         group_communication: group_communication.clone(),
                         rank_memory: rank_memory.clone(),
                         device_memory: device_memory.clone(),
+                        megatron_module_catalog: megatron_module_catalog.clone(),
                     }
                 }
             }
@@ -314,13 +495,10 @@ fn PlacementOverview(
 }
 
 fn placement_tooltip_style(position: PlacementTooltipPosition) -> String {
-    let left = position.x;
-    let top = position.y + 12.0;
-    format!(
-        "left: clamp(1rem, calc({left:.1}px - 22rem), calc(100vw - 45rem)); \
-         top: clamp(1rem, {top:.1}px, calc(100vh - 32rem)); \
-         width: min(44rem, calc(100vw - 2rem)); max-height: calc(100vh - 2rem);"
-    )
+    let _ = position;
+    "left: 50%; top: 50%; transform: translate(-50%, -50%); \
+     width: min(80rem, calc(100vw - 2rem)); height: calc(100vh - 2rem);"
+        .to_string()
 }
 
 fn placement_selection_is_pinned(active_rank: Option<i32>, pinned_rank: Option<i32>) -> bool {
@@ -334,6 +512,7 @@ fn PlacementSelectionDetail(
     group_sizes: Option<PlacementGroupSizes>,
     pinned: bool,
 ) -> Element {
+    let layout = process.layout.as_ref().map(format_rank_layout);
     let rank = process
         .rank
         .map(|value| format!("rank {value}"))
@@ -367,6 +546,9 @@ fn PlacementSelectionDetail(
             if !coordinates.is_empty() {
                 span { class: "font-mono", "{coordinates}" }
             }
+            if let Some(layout) = layout {
+                span { class: "font-mono font-medium text-cyan-800", "{layout}" }
+            }
             if let Some(sizes) = group_sizes {
                 span { class: "font-medium text-violet-800", "TP group {sizes.tensor}" }
                 span { class: "font-medium text-emerald-800", "DP group {sizes.data}" }
@@ -386,6 +568,7 @@ fn PlacementLinkedEvidence(
     group_communication: Option<Result<DataFrame>>,
     rank_memory: Option<Result<DataFrame>>,
     device_memory: Option<Result<DataFrame>>,
+    megatron_module_catalog: Option<Result<DataFrame>>,
 ) -> Element {
     let rank = process.rank;
     let status = process
@@ -445,6 +628,7 @@ fn PlacementLinkedEvidence(
                     }
                 }
             }
+            RankModulesPanel { rank, state: megatron_module_catalog }
             RankMemoryPanel { rank, local_rank: process.local_rank, memory, device_memory }
             div { class: "border-t border-gray-200 px-3 py-2",
                 div { class: "flex flex-wrap items-baseline justify-between gap-2",
@@ -474,6 +658,198 @@ fn PlacementLinkedEvidence(
                             communication,
                         }
                     }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn RankModulesPanel(rank: Option<i32>, state: Option<Result<DataFrame>>) -> Element {
+    let mut filter = use_signal(String::new);
+    let mut layers_only = use_signal(|| false);
+    let mut group_by_layer = use_signal(|| true);
+    let all_entries = state
+        .as_ref()
+        .and_then(|result| result.as_ref().ok())
+        .map(parse_module_catalog)
+        .unwrap_or_default();
+    let total_entries = all_entries.len();
+    let query = filter().trim().to_ascii_lowercase();
+    let entries = all_entries
+        .into_iter()
+        .filter(|entry| {
+            (!layers_only()
+                || entry.global_layer_index.is_some()
+                || entry.local_layer_index.is_some())
+                && module_matches_filter(entry, &query)
+        })
+        .collect::<Vec<_>>();
+    let shown_entries = entries.len();
+    let mut grouped_entries = BTreeMap::<Option<i32>, Vec<ModuleCatalogEntry>>::new();
+    for entry in entries.iter().cloned() {
+        grouped_entries
+            .entry(entry.global_layer_index.or(entry.local_layer_index))
+            .or_default()
+            .push(entry);
+    }
+    rsx! {
+        div { class: "border-t border-gray-200 px-3 py-2",
+            div { class: "flex flex-wrap items-baseline justify-between gap-2",
+                div { class: "text-xs font-medium text-gray-900", "Megatron modules and layers" }
+                if let Some(rank) = rank {
+                    div { class: "font-mono text-xs text-gray-500", "rank {rank} · {shown_entries} / {total_entries} modules" }
+                }
+            }
+            if rank.is_some() && total_entries > 0 {
+                div { class: "mt-2 flex flex-wrap items-center gap-2",
+                    input {
+                        r#type: "search",
+                        class: "min-w-64 flex-1 rounded border border-gray-300 px-2 py-1.5 font-mono text-xs text-gray-700 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500",
+                        placeholder: "Filter module, type, dtype, device, or L12",
+                        value: "{filter}",
+                        oninput: move |event| filter.set(event.value()),
+                    }
+                    button {
+                        r#type: "button",
+                        class: if layers_only() {
+                            "rounded border border-cyan-300 bg-cyan-50 px-2 py-1.5 text-xs font-medium text-cyan-800"
+                        } else {
+                            "rounded border border-gray-300 bg-white px-2 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50"
+                        },
+                        aria_pressed: layers_only().to_string(),
+                        onclick: move |_| layers_only.toggle(),
+                        "Layers only"
+                    }
+                    button {
+                        r#type: "button",
+                        class: if group_by_layer() {
+                            "rounded border border-violet-300 bg-violet-50 px-2 py-1.5 text-xs font-medium text-violet-800"
+                        } else {
+                            "rounded border border-gray-300 bg-white px-2 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50"
+                        },
+                        aria_pressed: group_by_layer().to_string(),
+                        onclick: move |_| group_by_layer.toggle(),
+                        "Group by layer"
+                    }
+                }
+            }
+            match state {
+                None => rsx! { div { class: "mt-2 text-xs text-gray-500", "Loading static model layout…" } },
+                Some(Err(error)) => rsx! { div { class: "mt-2 text-xs text-gray-500", "Static model layout unavailable · {error.display_message()}" } },
+                Some(Ok(_)) if rank.is_none() => rsx! { div { class: "mt-2 text-xs text-gray-500", "Select a rank to load its static model layout." } },
+                Some(Ok(_)) if total_entries == 0 => rsx! { div { class: "mt-2 text-xs text-gray-500", "This rank has not reported a static Megatron module catalog." } },
+                Some(Ok(_)) if entries.is_empty() => rsx! { div { class: "mt-2 text-xs text-gray-500", "No modules match the current filters." } },
+                Some(Ok(_)) => rsx! {
+                    div {
+                        class: "mt-2 overflow-auto rounded border border-gray-200",
+                        style: "max-height: 60vh;",
+                        if group_by_layer() {
+                            for (layer, group) in grouped_entries {
+                                ModuleLayerGroup {
+                                    layer,
+                                    entries: group,
+                                    expanded: !query.is_empty(),
+                                }
+                            }
+                        } else {
+                            for entry in entries {
+                                ModuleCatalogRow { entry }
+                            }
+                        }
+                    }
+                },
+            }
+        }
+    }
+}
+
+#[component]
+fn ModuleLayerGroup(
+    layer: Option<i32>,
+    entries: Vec<ModuleCatalogEntry>,
+    expanded: bool,
+) -> Element {
+    let label = layer
+        .map(|index| format!("Layer {index}"))
+        .unwrap_or_else(|| "Shared / non-layer modules".to_string());
+    let parameters = entries
+        .iter()
+        .map(|entry| entry.parameter_count)
+        .sum::<u64>();
+    rsx! {
+        details { class: "border-b border-gray-200 last:border-b-0", open: expanded,
+            summary { class: "flex cursor-pointer list-none items-center justify-between gap-3 bg-gray-50 px-2 py-2 text-xs hover:bg-gray-100",
+                span { class: "font-semibold text-gray-800", "{label}" }
+                span { class: "font-mono text-gray-500", "{entries.len()} modules · {format_parameter_count(parameters)} params" }
+            }
+            div { class: "border-t border-gray-100",
+                for entry in entries {
+                    ModuleCatalogRow { entry }
+                }
+            }
+        }
+    }
+}
+
+fn module_matches_filter(entry: &ModuleCatalogEntry, query: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+    let layer = entry
+        .global_layer_index
+        .or(entry.local_layer_index)
+        .map(|index| format!("l{index}"))
+        .unwrap_or_default();
+    [
+        entry.module_path.as_str(),
+        entry.module_type.as_str(),
+        entry.dtype.as_str(),
+        entry.device.as_str(),
+        layer.as_str(),
+    ]
+    .iter()
+    .any(|value| value.to_ascii_lowercase().contains(query))
+}
+
+#[component]
+fn ModuleCatalogRow(entry: ModuleCatalogEntry) -> Element {
+    let indent = entry.depth.min(8) as f32 * 0.75;
+    let module_type = entry
+        .module_type
+        .rsplit('.')
+        .next()
+        .unwrap_or(entry.module_type.as_str())
+        .to_string();
+    let layer = entry
+        .global_layer_index
+        .map(|index| format!("L{index}"))
+        .or_else(|| {
+            entry
+                .local_layer_index
+                .map(|index| format!("local L{index}"))
+        });
+    let parameters = format_parameter_count(entry.parameter_count);
+    let trainable = format_parameter_count(entry.trainable_parameter_count);
+    let placement = [entry.dtype.as_str(), entry.device.as_str()]
+        .into_iter()
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" · ");
+    rsx! {
+        div {
+            class: "grid grid-cols-[minmax(16rem,1fr)_auto] gap-3 border-b border-gray-100 px-2 py-1.5 text-xs last:border-b-0",
+            div { class: "min-w-0", style: "padding-left: {indent}rem;",
+                div { class: if entry.is_leaf { "truncate font-mono font-medium text-gray-900" } else { "truncate font-mono text-gray-700" }, "{entry.module_path}" }
+                div { class: "truncate text-gray-500", "chunk {entry.model_chunk} · {module_type}" }
+            }
+            div { class: "text-right",
+                if let Some(layer) = layer {
+                    div { class: "font-mono font-semibold text-cyan-800", "{layer}" }
+                }
+                div { class: "font-mono text-gray-600", "{parameters} params · {trainable} trainable" }
+                if !placement.is_empty() {
+                    div { class: "font-mono text-gray-500", "{placement}" }
                 }
             }
         }
@@ -620,6 +996,141 @@ fn group_communication_evidence(state: Option<&Result<DataFrame>>) -> GroupCommu
             GroupCommunicationEvidence::Loaded(parse_group_communication(dataframe))
         }
     }
+}
+
+fn rank_layout_evidence(state: Option<&Result<DataFrame>>) -> BTreeMap<i32, RankLayoutSummary> {
+    let Some(Ok(dataframe)) = state else {
+        return BTreeMap::new();
+    };
+    let index = |name: &str| dataframe.names.iter().position(|column| column == name);
+    let (
+        Some(recorded_at),
+        Some(rank),
+        Some(model_chunk),
+        Some(layer_start),
+        Some(layer_end),
+        Some(module_count),
+    ) = (
+        index("recorded_at_ns"),
+        index("rank"),
+        index("model_chunk"),
+        index("layer_start"),
+        index("layer_end"),
+        index("module_count"),
+    )
+    else {
+        return BTreeMap::new();
+    };
+    let mut latest = BTreeMap::<(i32, i32), (i64, i32, i32, usize)>::new();
+    for row in dataframe.iter() {
+        let Some(rank) = ele_i64(row.get(rank)).and_then(|value| i32::try_from(value).ok()) else {
+            continue;
+        };
+        let Some(chunk) = ele_i64(row.get(model_chunk)).and_then(|value| i32::try_from(value).ok())
+        else {
+            continue;
+        };
+        let timestamp = ele_i64(row.get(recorded_at)).unwrap_or_default();
+        let start = ele_i64(row.get(layer_start))
+            .and_then(|value| i32::try_from(value).ok())
+            .unwrap_or(-1);
+        let end = ele_i64(row.get(layer_end))
+            .and_then(|value| i32::try_from(value).ok())
+            .unwrap_or(-1);
+        let modules = ele_i64(row.get(module_count))
+            .and_then(|value| usize::try_from(value).ok())
+            .unwrap_or_default();
+        let key = (rank, chunk);
+        if latest
+            .get(&key)
+            .is_none_or(|(current, _, _, _)| timestamp > *current)
+        {
+            latest.insert(key, (timestamp, start, end, modules));
+        }
+    }
+    let ranks_with_chunks = latest
+        .keys()
+        .filter_map(|(rank, chunk)| (*chunk >= 0).then_some(*rank))
+        .collect::<BTreeSet<_>>();
+    let mut summaries = BTreeMap::<i32, RankLayoutSummary>::new();
+    for ((rank, chunk), (_, start, end, modules)) in latest {
+        if chunk < 0 && ranks_with_chunks.contains(&rank) {
+            continue;
+        }
+        let summary = summaries.entry(rank).or_default();
+        summary.module_count = summary.module_count.saturating_add(modules);
+        if chunk >= 0 {
+            summary.model_chunks += 1;
+        }
+        if start >= 0 {
+            summary.layer_start = Some(
+                summary
+                    .layer_start
+                    .map_or(start, |current| current.min(start)),
+            );
+        }
+        if end >= 0 {
+            summary.layer_end = Some(summary.layer_end.map_or(end, |current| current.max(end)));
+        }
+    }
+    summaries
+}
+
+fn parse_module_catalog(dataframe: &DataFrame) -> Vec<ModuleCatalogEntry> {
+    let index = |name: &str| dataframe.names.iter().position(|column| column == name);
+    let (
+        Some(model_chunk),
+        Some(module_path),
+        Some(module_type),
+        Some(depth),
+        Some(local_layer),
+        Some(global_layer),
+        Some(parameters),
+        Some(trainable),
+        Some(dtype),
+        Some(device),
+        Some(is_leaf),
+    ) = (
+        index("model_chunk"),
+        index("module_path"),
+        index("module_type"),
+        index("depth"),
+        index("local_layer_index"),
+        index("global_layer_index"),
+        index("parameter_count"),
+        index("trainable_parameter_count"),
+        index("dtype"),
+        index("device"),
+        index("is_leaf"),
+    )
+    else {
+        return Vec::new();
+    };
+    dataframe
+        .iter()
+        .filter_map(|row| {
+            let local_layer_index = ele_i64(row.get(local_layer))
+                .and_then(|value| i32::try_from(value).ok())
+                .filter(|value| *value >= 0);
+            let global_layer_index = ele_i64(row.get(global_layer))
+                .and_then(|value| i32::try_from(value).ok())
+                .filter(|value| *value >= 0);
+            Some(ModuleCatalogEntry {
+                model_chunk: i32::try_from(ele_i64(row.get(model_chunk))?).ok()?,
+                module_path: ele_string(row.get(module_path))?,
+                module_type: ele_string(row.get(module_type))?,
+                depth: usize::try_from(ele_i64(row.get(depth))?).ok()?,
+                local_layer_index,
+                global_layer_index,
+                parameter_count: u64::try_from(ele_i64(row.get(parameters))?).unwrap_or_default(),
+                trainable_parameter_count: u64::try_from(ele_i64(row.get(trainable))?)
+                    .unwrap_or_default(),
+                dtype: ele_string(row.get(dtype)).unwrap_or_default(),
+                device: ele_string(row.get(device)).unwrap_or_default(),
+                is_leaf: ele_i64(row.get(is_leaf)).unwrap_or_default() != 0,
+            })
+        })
+        .collect()
 }
 
 fn rank_memory_evidence(state: Option<&Result<DataFrame>>) -> RankMemoryEvidence {
@@ -902,6 +1413,18 @@ fn format_memory_ratio(allocated_mb: f64, reserved_mb: f64) -> String {
     }
 }
 
+fn format_parameter_count(count: u64) -> String {
+    if count >= 1_000_000_000 {
+        format!("{:.2}B", count as f64 / 1_000_000_000.0)
+    } else if count >= 1_000_000 {
+        format!("{:.2}M", count as f64 / 1_000_000.0)
+    } else if count >= 1_000 {
+        format!("{:.1}K", count as f64 / 1_000.0)
+    } else {
+        count.to_string()
+    }
+}
+
 fn format_binary_bytes(bytes: u64) -> String {
     format_bytes(bytes)
 }
@@ -1022,13 +1545,19 @@ fn PlacementCell(
     } else {
         format!(" · {coordinates}")
     };
+    let layout_detail = process
+        .layout
+        .as_ref()
+        .map(|layout| format!(" · {}", format_rank_layout(layout)))
+        .unwrap_or_default();
     let title = format!(
-        "{rank_label} · {host} · GPU{local_rank} · {status} · {role}{}{}{}",
+        "{rank_label} · {host} · GPU{local_rank} · {status} · {role}{}{}{}{}",
         coordinate_detail,
         group_name
             .map(|name| format!(" · {name}"))
             .unwrap_or_default(),
         memory_detail,
+        layout_detail,
     );
     let pinned_host = host.clone();
     let pinned = INVESTIGATION_CONTEXT.read().rank == rank;
@@ -1122,6 +1651,24 @@ fn coordinate<'a>(process: &'a PlacementProcess, dimension: &str) -> Option<&'a 
         .coordinates
         .iter()
         .find_map(|(key, value)| (key == dimension).then_some(value.as_str()))
+}
+
+fn coordinate_i32(process: &PlacementProcess, dimension: &str) -> Option<i32> {
+    coordinate(process, dimension)?.parse().ok()
+}
+
+fn format_rank_layout(layout: &RankLayoutSummary) -> String {
+    let layers = match (layout.layer_start, layout.layer_end) {
+        (Some(start), Some(end)) if start == end => format!("L{start}"),
+        (Some(start), Some(end)) => format!("L{start}–{end}"),
+        _ => "layers unknown".to_string(),
+    };
+    let chunks = (layout.model_chunks > 1).then(|| format!(" · {} chunks", layout.model_chunks));
+    format!(
+        "{layers} · {} modules{}",
+        layout.module_count,
+        chunks.unwrap_or_default()
+    )
 }
 
 fn placement_group_membership(
@@ -1257,7 +1804,7 @@ fn parse_coordinates(role: Option<&str>) -> Vec<(String, String)> {
         .collect()
 }
 
-fn build_placement(nodes: &[Node]) -> PlacementModel {
+fn build_placement(nodes: &[Node], layouts: &BTreeMap<i32, RankLayoutSummary>) -> PlacementModel {
     let mut hosts: BTreeMap<String, Vec<PlacementProcess>> = BTreeMap::new();
     let mut ranks = BTreeSet::new();
     let mut expected_ranks = 0usize;
@@ -1287,6 +1834,7 @@ fn build_placement(nodes: &[Node]) -> PlacementModel {
             coordinates,
             status: node.status.clone(),
             timestamp: node.timestamp,
+            layout: node.rank.and_then(|rank| layouts.get(&rank).cloned()),
         });
     }
 
@@ -1361,7 +1909,7 @@ mod tests {
                 ..Default::default()
             })
             .collect::<Vec<_>>();
-        let placement = build_placement(&nodes);
+        let placement = build_placement(&nodes, &BTreeMap::new());
 
         assert_eq!(placement.hosts.len(), 8);
         assert_eq!(placement.observed_ranks, 64);
@@ -1526,5 +2074,77 @@ mod tests {
         assert!(heat.contains("#ffffff"));
         assert!(memory_heat_style(Some(&sample), Some(PlacementGroup::Focus)).is_empty());
         assert!(memory_heat_style(None, None).is_empty());
+    }
+
+    #[test]
+    fn rank_layout_aggregates_model_chunks_and_ignores_initial_snapshot() {
+        let dataframe = DataFrame::new(
+            vec![
+                "recorded_at_ns".into(),
+                "rank".into(),
+                "model_chunk".into(),
+                "layer_start".into(),
+                "layer_end".into(),
+                "module_count".into(),
+            ],
+            vec![
+                Seq::SeqI64(vec![1, 2, 3]),
+                Seq::SeqI32(vec![7, 7, 7]),
+                Seq::SeqI32(vec![-1, 0, 1]),
+                Seq::SeqI32(vec![-1, 0, 8]),
+                Seq::SeqI32(vec![-1, 7, 15]),
+                Seq::SeqI64(vec![0, 120, 130]),
+            ],
+        );
+        let state = Ok(dataframe);
+        let layouts = rank_layout_evidence(Some(&state));
+        let layout = layouts.get(&7).unwrap();
+        assert_eq!(layout.layer_start, Some(0));
+        assert_eq!(layout.layer_end, Some(15));
+        assert_eq!(layout.module_count, 250);
+        assert_eq!(layout.model_chunks, 2);
+        assert_eq!(format_rank_layout(layout), "L0–15 · 250 modules · 2 chunks");
+    }
+
+    #[test]
+    fn module_catalog_preserves_layer_and_parameter_metadata() {
+        let dataframe = DataFrame::new(
+            vec![
+                "model_chunk".into(),
+                "module_path".into(),
+                "module_type".into(),
+                "depth".into(),
+                "local_layer_index".into(),
+                "global_layer_index".into(),
+                "parameter_count".into(),
+                "trainable_parameter_count".into(),
+                "dtype".into(),
+                "device".into(),
+                "is_leaf".into(),
+            ],
+            vec![
+                Seq::SeqI32(vec![0]),
+                Seq::SeqText(vec!["decoder.layers.0.mlp".into()]),
+                Seq::SeqText(vec!["megatron.MLP".into()]),
+                Seq::SeqI64(vec![4]),
+                Seq::SeqI32(vec![0]),
+                Seq::SeqI32(vec![8]),
+                Seq::SeqI64(vec![1_048_576]),
+                Seq::SeqI64(vec![1_048_576]),
+                Seq::SeqText(vec!["torch.float16".into()]),
+                Seq::SeqText(vec!["cuda:0".into()]),
+                Seq::SeqI32(vec![1]),
+            ],
+        );
+        let entries = parse_module_catalog(&dataframe);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].global_layer_index, Some(8));
+        assert_eq!(entries[0].parameter_count, 1_048_576);
+        assert!(entries[0].is_leaf);
+        assert_eq!(format_parameter_count(entries[0].parameter_count), "1.05M");
+        assert!(module_matches_filter(&entries[0], "mlp"));
+        assert!(module_matches_filter(&entries[0], "float16"));
+        assert!(module_matches_filter(&entries[0], "l8"));
+        assert!(!module_matches_filter(&entries[0], "attention"));
     }
 }


### PR DESCRIPTION
## Summary
- capture Megatron parallel coordinates, rank layer ranges, and module catalogs for cluster-wide inspection
- add physical/logical placement, rank module filtering/grouping, step trends, and clearer memory evidence to the web UI
- align optimizer telemetry with completed training steps, flush deferred samples, and keep rank heartbeats within the stale TTL

## Test plan
- [x] `.venv/bin/python -m pytest -q tests/regression/profiling/test_torch_probe_sampling.py tests/regression/ext/test_megatron_contract.py`
- [x] `cd web && cargo test`
- [x] `cd web && cargo clippy --all-targets -- -D warnings`
- [x] Run Qwen3-8B for 20 iterations on 8 GPUs with TP=2, PP=2, DP=2
- [x] Verify cluster queries return all 8 ranks and every rank ends at allocator Step 20


Made with [Cursor](https://cursor.com)