### PR TITLE
fix(web): improve distributed memory controls

### DIFF
--- a/web/assets/tailwind.css
+++ b/web/assets/tailwind.css
@@ -2063,6 +2063,10 @@ video {
   border-color: rgb(96 165 250 / var(--tw-border-opacity, 1));
 }
 
+.border-blue-400\/60 {
+  border-color: rgb(96 165 250 / 0.6);
+}
+
 .border-blue-50 {
   --tw-border-opacity: 1;
   border-color: rgb(239 246 255 / var(--tw-border-opacity, 1));
@@ -2227,6 +2231,11 @@ video {
 .border-red-200 {
   --tw-border-opacity: 1;
   border-color: rgb(254 202 202 / var(--tw-border-opacity, 1));
+}
+
+.border-red-300 {
+  --tw-border-opacity: 1;
+  border-color: rgb(252 165 165 / var(--tw-border-opacity, 1));
 }
 
 .border-red-400 {
@@ -4809,6 +4818,11 @@ video {
   padding-right: 0px;
 }
 
+.px-0\.5 {
+  padding-left: 0.125rem;
+  padding-right: 0.125rem;
+}
+
 .px-1 {
   padding-left: 0.25rem;
   padding-right: 0.25rem;
@@ -6068,6 +6082,11 @@ video {
   border-color: rgb(209 213 219 / var(--tw-border-opacity, 1));
 }
 
+.hover\:border-red-400:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(248 113 113 / var(--tw-border-opacity, 1));
+}
+
 .hover\:border-slate-600:hover {
   --tw-border-opacity: 1;
   border-color: rgb(71 85 105 / var(--tw-border-opacity, 1));
@@ -6129,6 +6148,10 @@ video {
 .hover\:bg-blue-500:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(59 130 246 / var(--tw-bg-opacity, 1));
+}
+
+.hover\:bg-blue-500\/30:hover {
+  background-color: rgb(59 130 246 / 0.3);
 }
 
 .hover\:bg-blue-600:hover {
@@ -7278,6 +7301,11 @@ video {
 .focus-visible\:ring-blue-700:focus-visible {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(29 78 216 / var(--tw-ring-opacity, 1));
+}
+
+.focus-visible\:ring-red-500:focus-visible {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(239 68 68 / var(--tw-ring-opacity, 1));
 }
 
 .focus-visible\:ring-offset-1:focus-visible {

--- a/web/src/next/components.rs
+++ b/web/src/next/components.rs
@@ -154,10 +154,10 @@ pub fn InvestigationBar(support: super::page_registry::InvestigationSupport) -> 
                 ContextLink { route: NextRoute::Investigate {}, label: "Investigate" }
                 button {
                     r#type: "button",
-                    class: "ml-1 rounded px-1.5 py-1 text-gray-600 hover:bg-white hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-600",
+                    class: "ml-1 rounded border border-red-300 bg-red-50 px-2.5 py-1 font-medium text-red-700 shadow-sm hover:border-red-400 hover:bg-red-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500",
                     aria_label: "Clear pinned investigation context",
                     onclick: move |_| clear_investigation_context(),
-                    "Clear"
+                    "Clear selection"
                 }
             }
         }

--- a/web/src/next/pages/memory.rs
+++ b/web/src/next/pages/memory.rs
@@ -416,13 +416,15 @@ fn DeviceMap(devices: Vec<DeviceMemory>) -> Element {
     }
 
     rsx! {
-        div { class: "grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-3 border-t border-gray-100 pt-3",
-            for (host, rows) in hosts {
-                div { class: "rounded-md border border-gray-200 bg-gray-50/60 p-2",
-                    div { class: "mb-2 truncate text-xs font-medium text-gray-700", title: "{host}", "{host}" }
-                    div { class: "grid grid-cols-4 gap-1.5",
-                        for row in rows {
-                            {
+        div { class: "border-t border-gray-100 pt-3",
+            div { class: "mb-2 text-xs text-gray-500", "C = current usage · P = window peak" }
+            div { class: "grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-3",
+                for (host, rows) in hosts {
+                    div { class: "rounded-md border border-gray-200 bg-gray-50/60 p-2",
+                        div { class: "mb-2 truncate text-xs font-medium text-gray-700", title: "{host}", "{host}" }
+                        div { class: "grid grid-cols-4 gap-1",
+                            for row in rows {
+                                {
                                 let active = context.device_id == Some(row.device_id)
                                     && (context.rank == row.rank || row.rank.is_none());
                                 let ratio = percent(row.current_bytes, row.total_bytes);
@@ -430,26 +432,30 @@ fn DeviceMap(devices: Vec<DeviceMemory>) -> Element {
                                 let host_for_click = row.host.clone();
                                 let rank = row.rank;
                                 let device_id = row.device_id;
+                                let coordinate_label = rank
+                                    .map(|rank| format!("Rank {rank} · GPU {device_id}"))
+                                    .unwrap_or_else(|| format!("GPU {device_id}"));
                                 rsx! {
                                     button {
                                         r#type: "button",
                                         class: if active {
-                                            "min-h-14 rounded border border-blue-500 bg-blue-50 px-1 py-1 text-left ring-1 ring-blue-200"
+                                            "min-h-14 min-w-0 rounded border border-blue-500 bg-blue-50 px-0.5 py-1 text-left ring-1 ring-blue-200"
                                         } else {
-                                            "min-h-14 rounded border border-gray-200 bg-white px-1 py-1 text-left hover:border-blue-300 hover:bg-blue-50/40"
+                                            "min-h-14 min-w-0 rounded border border-gray-200 bg-white px-0.5 py-1 text-left hover:border-blue-300 hover:bg-blue-50/40"
                                         },
-                                        title: "GPU {device_id} · current {ratio:.1}% · window peak {peak:.1}% · {row.sample_count} samples",
+                                        title: "{coordinate_label} · current {ratio:.1}% · window peak {peak:.1}% · {row.sample_count} samples",
                                         aria_pressed: active.to_string(),
                                         onclick: move |_| set_memory_device_context(rank, Some(&host_for_click), device_id),
-                                        div { class: "font-mono text-xs font-semibold text-gray-900", "G{device_id}" }
-                                        div { class: "text-xs tabular-nums text-gray-600", "C {ratio:.0}%" }
-                                        div { class: "text-xs tabular-nums text-gray-500", "P {peak:.0}%" }
+                                        div { class: "whitespace-nowrap font-mono text-xs font-semibold text-gray-900", "GPU{device_id}" }
+                                        div { class: "whitespace-nowrap text-xs tabular-nums text-gray-600", "C{ratio:.0}%" }
+                                        div { class: "whitespace-nowrap text-xs tabular-nums text-gray-500", "P{peak:.0}%" }
                                         div { class: "mt-1 h-1 rounded bg-gray-100",
                                             div { class: "h-full rounded bg-violet-500", style: "width: {ratio.clamp(0.0, 100.0):.1}%;" }
                                         }
                                     }
                                 }
                             }
+                        }
                         }
                     }
                 }
@@ -788,19 +794,21 @@ fn device_history_sql(window_us: u64) -> String {
       ORDER BY ts ASC LIMIT 1920")
 }
 
-const ALLOCATOR_SQL: &str = "SELECT rank, local_step, round(allocated, 1) AS allocated_mb, \
+const ALLOCATOR_SQL: &str = "WITH allocator AS (SELECT * FROM python.torch_trace) \
+  SELECT rank, local_step, round(allocated, 1) AS allocated_mb, \
   round(max_allocated, 1) AS peak_allocated_mb, round(cached, 1) AS reserved_mb, \
   round(CASE WHEN cached > 0 THEN allocated * 100.0 / cached ELSE 0 END, 1) AS allocated_of_reserved_pct \
-  FROM python.torch_trace WHERE rank >= 0 AND allocated >= 0 AND stage LIKE 'post %' \
+  FROM allocator WHERE rank >= 0 AND allocated >= 0 AND stage LIKE 'post %' \
   ORDER BY local_step DESC, seq DESC LIMIT 1";
 
-const ALLOCATION_EVIDENCE_SQL: &str = "SELECT rank, module, stage, count(*) AS samples, \
+const ALLOCATION_EVIDENCE_SQL: &str = "WITH trace_samples AS (SELECT * FROM python.torch_trace) \
+  SELECT rank, module, stage, count(*) AS samples, \
   round(avg(allocated_delta), 1) AS avg_alloc_delta_mb, \
   round(max(allocated_delta), 1) AS max_alloc_delta_mb, \
   round(max(max_allocated_delta), 1) AS peak_growth_mb \
-  FROM python.torch_trace WHERE stage LIKE 'post %' AND allocated_delta > 0 \
+  FROM trace_samples WHERE stage LIKE 'post %' AND allocated_delta > 0 \
     AND module IS NOT NULL AND module != '' AND module != 'None' \
-    AND local_step >= GREATEST(COALESCE((SELECT max(local_step) FROM python.torch_trace), 0) - 9, 1) \
+    AND local_step >= GREATEST(COALESCE((SELECT max(local_step) FROM trace_samples), 0) - 9, 1) \
   GROUP BY rank, module, stage ORDER BY peak_growth_mb DESC LIMIT 20";
 
 fn parse_devices(dataframe: &DataFrame, nodes: &[Node]) -> Vec<DeviceMemory> {

--- a/web/src/next/pages/training_placement.rs
+++ b/web/src/next/pages/training_placement.rs
@@ -326,8 +326,8 @@ fn LogicalTopology(placement: PlacementModel, local_step: Option<i64>) -> Elemen
 fn LogicalRankCell(process: PlacementProcess, pp: i32, local_step: Option<i64>) -> Element {
     let rank = process.rank;
     let rank_label = rank
-        .map(|rank| format!("R{rank}"))
-        .unwrap_or_else(|| "R?".to_string());
+        .map(|rank| format!("Rank {rank}"))
+        .unwrap_or_else(|| "Rank ?".to_string());
     let layer_label = process
         .layout
         .as_ref()
@@ -403,7 +403,7 @@ fn PlacementOverview(
                 div { class: "flex items-center gap-2",
                     span { class: "text-xs font-medium uppercase tracking-wide text-gray-500", "Overview" }
                     if let Some(rank) = active_rank {
-                        span { class: "font-mono text-xs font-semibold text-blue-700", "R{rank}" }
+                        span { class: "font-mono text-xs font-semibold text-blue-700", "Rank {rank}" }
                         if active_is_pinned {
                             span { class: "text-xs text-blue-600", "pinned" }
                         }
@@ -1442,7 +1442,7 @@ fn format_rank_members(members: &[i32]) -> String {
     let mut label = members
         .iter()
         .take(LIMIT)
-        .map(|rank| format!("R{rank}"))
+        .map(|rank| format!("Rank {rank}"))
         .collect::<Vec<_>>()
         .join(" ");
     if members.len() > LIMIT {
@@ -1503,8 +1503,8 @@ fn PlacementCell(
     let rank = process.rank;
     let local_device_id = process.local_rank;
     let rank_label = rank
-        .map(|value| format!("R{value}"))
-        .unwrap_or_else(|| "R?".to_string());
+        .map(|value| format!("Rank {value}"))
+        .unwrap_or_else(|| "Rank ?".to_string());
     let local_rank = process
         .local_rank
         .map(|value| value.to_string())

--- a/web/src/next/sidebar.rs
+++ b/web/src/next/sidebar.rs
@@ -114,6 +114,18 @@ fn SidebarRail(
                     }
                 }
             }
+            if compact {
+                div { class: "shrink-0 px-2 pt-2",
+                    button {
+                        r#type: "button",
+                        class: "flex h-10 w-full items-center justify-center rounded-lg border border-blue-400/60 bg-blue-500/20 text-blue-200 shadow-sm hover:border-blue-300 hover:bg-blue-500/30 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400",
+                        title: "Expand sidebar",
+                        aria_label: "Expand sidebar",
+                        onclick: move |_| on_toggle_compact.call(()),
+                        Icon { icon: &icondata::AiMenuUnfoldOutlined, class: "h-5 w-5" }
+                    }
+                }
+            }
             div { class: "shrink-0 px-2 pt-2",
                 RailAction {
                     label: "Search pages and commands · ⌘K".to_string(),
@@ -327,7 +339,7 @@ fn DashboardControls() -> Element {
         ToggleRow {
             label: "Auto refresh",
             checked: enabled,
-            onchange: move |_| *DASHBOARD_AUTO_REFRESH.write() = !*DASHBOARD_AUTO_REFRESH.read(),
+            onchange: move |checked| *DASHBOARD_AUTO_REFRESH.write() = checked,
         }
         button {
             r#type: "button",
@@ -350,8 +362,8 @@ fn DistributedControls() -> Element {
         ToggleRow {
             label: "Cluster fan-out",
             checked: cluster,
-            onchange: move |_| {
-                *DISTRIBUTED_CLUSTER_SCOPE.write() = !*DISTRIBUTED_CLUSTER_SCOPE.read();
+            onchange: move |checked| {
+                *DISTRIBUTED_CLUSTER_SCOPE.write() = checked;
             },
         }
         RangeControl {
@@ -383,7 +395,10 @@ fn MemoryControls() -> Element {
         ToggleRow {
             label: "Cluster fan-out",
             checked: cluster,
-            onchange: move |_| *MEMORY_CLUSTER_SCOPE.write() = !*MEMORY_CLUSTER_SCOPE.read(),
+            onchange: move |checked| {
+                *MEMORY_CLUSTER_SCOPE.write() = checked;
+                *MEMORY_REFRESH.write() += 1;
+            },
         }
         RangeControl {
             label: "Window (minutes)",
@@ -707,7 +722,7 @@ fn StackControls(route: NextRoute) -> Element {
             ToggleRow {
                 label: "Cluster fan-out",
                 checked: cluster,
-                onchange: move |_| *STACK_DIST_CLUSTER.write() = !*STACK_DIST_CLUSTER.read(),
+                onchange: move |checked| *STACK_DIST_CLUSTER.write() = checked,
             }
             button {
                 r#type: "button",
@@ -808,7 +823,7 @@ fn ControlSummary(scope: String, update: String) -> Element {
 }
 
 #[component]
-fn ToggleRow(label: &'static str, checked: bool, onchange: EventHandler<()>) -> Element {
+fn ToggleRow(label: &'static str, checked: bool, onchange: EventHandler<bool>) -> Element {
     rsx! {
         label { class: "flex cursor-pointer items-center justify-between gap-3 text-xs text-slate-300",
             span { "{label}" }
@@ -816,7 +831,7 @@ fn ToggleRow(label: &'static str, checked: bool, onchange: EventHandler<()>) -> 
                 r#type: "checkbox",
                 checked,
                 class: "h-5 w-5 rounded border-slate-600 bg-slate-900 text-blue-600 focus:ring-2 focus:ring-blue-400 focus:ring-offset-1 focus:ring-offset-slate-900",
-                onchange: move |_| onchange.call(()),
+                oninput: move |event| onchange.call(event.checked()),
             }
         }
     }


### PR DESCRIPTION
## Summary
- refresh cluster-scoped Memory evidence immediately and broadcast allocator queries across all ranks
- clarify rank/GPU labels, memory abbreviations, and pinned-context clearing
- keep a prominent sidebar expand control available in compact mode

## Test plan
- [x] `cargo test memory`
- [x] `cargo test next::sidebar`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Run Qwen3-8B for 20 steps on 8 GPUs and verify allocator rows for Rank 0-7
- [x] Rebuild and deploy the Dioxus web bundle

Made with [Cursor](https://cursor.com)